### PR TITLE
[Backport] 8274345: make build-test-lib is broken.

### DIFF
--- a/make/test/BuildTestLib.gmk
+++ b/make/test/BuildTestLib.gmk
@@ -36,9 +36,10 @@ TEST_LIB_SUPPORT := $(SUPPORT_OUTPUTDIR)/test/lib
 
 $(eval $(call SetupJavaCompilation, BUILD_WB_JAR, \
     TARGET_RELEASE := $(TARGET_RELEASE_NEWJDK_UPGRADED), \
-    SRC := $(TEST_LIB_SOURCE_DIR)/sun, \
+    SRC := $(TEST_LIB_SOURCE_DIR)/sun $(TEST_LIB_SOURCE_DIR)/jdk/test/whitebox/parser, \
     BIN := $(TEST_LIB_SUPPORT)/wb_classes, \
     JAR := $(TEST_LIB_SUPPORT)/wb.jar, \
+    DISABLED_WARNINGS := deprecation removal, \
 ))
 
 TARGETS += $(BUILD_WB_JAR)
@@ -50,7 +51,7 @@ $(eval $(call SetupJavaCompilation, BUILD_TEST_LIB_JAR, \
     BIN := $(TEST_LIB_SUPPORT)/test-lib_classes, \
     HEADERS := $(TEST_LIB_SUPPORT)/test-lib_headers, \
     JAR := $(TEST_LIB_SUPPORT)/test-lib.jar, \
-    DISABLED_WARNINGS := try deprecation rawtypes unchecked serial cast, \
+    DISABLED_WARNINGS := try deprecation rawtypes unchecked serial cast removal, \
 ))
 
 TARGETS += $(BUILD_TEST_LIB_JAR)


### PR DESCRIPTION
Summary: Backport 8274345, see detail in https://bugs.openjdk.org/browse/JDK-8274345.

Test Plan: All test

Reviewed-by: yulei

Issue: https://github.com/dragonwell-project/dragonwell17/issues/69