### PR TITLE
[Wisp] Port JKU coroutine support to JDK17.

### DIFF
--- a/src/hotspot/cpu/x86/sharedRuntime_x86_64.cpp
+++ b/src/hotspot/cpu/x86/sharedRuntime_x86_64.cpp
@@ -64,6 +64,11 @@
 #include "jvmci/jvmciJavaClasses.hpp"
 #endif
 
+#include "runtime/coroutine.hpp"
+
+void coroutine_start(Coroutine* coroutine, jobject coroutineObj);
+
+
 #define __ masm->
 
 const int StackAlignmentInSlots = StackAlignmentInBytes / VMRegImpl::stack_slot_size;
@@ -1526,6 +1531,8 @@ static void gen_special_dispatch(MacroAssembler* masm,
                                                  receiver_reg, member_reg, /*for_compiler_entry:*/ true);
 }
 
+void create_switchTo_contents(MacroAssembler *masm, int start, OopMapSet* oop_maps, int &stack_slots, int total_in_args, BasicType *in_sig_bt, VMRegPair *in_regs, BasicType ret_type, bool terminate);
+
 // ---------------------------------------------------------------------------
 // Generate a native wrapper for a given method.  The method takes arguments
 // in the Java compiled code convention, marshals them to the native
@@ -1799,6 +1806,16 @@ nmethod* SharedRuntime::generate_native_wrapper(MacroAssembler* masm,
 
   // Generate stack overflow check
   __ bang_stack_with_offset((int)StackOverflow::stack_shadow_zone_size());
+
+  if (EnableCoroutine) {
+    // the coroutine support methods have a hand-coded fast version that will handle the most common cases
+    if (method->intrinsic_id() == vmIntrinsics::_switchTo) {
+      create_switchTo_contents(masm, start, oop_maps, stack_slots, total_in_args, in_sig_bt, in_regs, ret_type, false);
+    } else if (method->intrinsic_id() == vmIntrinsics::_switchToAndTerminate ||
+        method->intrinsic_id() == vmIntrinsics::_switchToAndExit) {
+      create_switchTo_contents(masm, start, oop_maps, stack_slots, total_in_args, in_sig_bt, in_regs, ret_type, true);
+    }
+  }
 
   // Generate a new frame for the wrapper.
   __ enter();
@@ -2302,6 +2319,22 @@ nmethod* SharedRuntime::generate_native_wrapper(MacroAssembler* masm,
   }
 
   // Return
+  if (EnableCoroutine &&
+      (method->intrinsic_id() == vmIntrinsics::_switchToAndTerminate ||
+       method->intrinsic_id() == vmIntrinsics::_switchToAndExit)) {
+
+    Label normal;
+    __ lea(rcx, RuntimeAddress((unsigned char*)coroutine_start));
+    __ cmpq(Address(rsp, 0), rcx);
+    __ jcc(Assembler::notEqual, normal);
+
+    __ movq(c_rarg0, Address(rsp, HeapWordSize * 2));
+    __ movq(c_rarg1, Address(rsp, HeapWordSize * 3));
+
+    __ bind(normal);
+
+    __ ret(0);        // <-- this will jump to the stored IP of the target coroutine
+  }
 
   __ ret(0);
 
@@ -3907,4 +3940,204 @@ void SharedRuntime::compute_move_order(const BasicType* in_sig_bt,
   ComputeMoveOrder order(total_in_args, in_regs,
                          total_out_args, out_regs,
                          in_sig_bt, arg_order, tmp_vmreg);
+}
+
+
+void stop_if(MacroAssembler *masm, Assembler::Condition condition, const char* message) {
+  Label skip;
+  __ jcc(masm->negate_condition(condition), skip);
+
+  __ stop(message);
+  __ int3();
+
+  __ bind(skip);
+}
+
+void stop_if_null(MacroAssembler *masm, Register reg, const char* message) {
+  __ testptr(reg, reg);
+  stop_if(masm, Assembler::zero, message);
+}
+
+void stop_if_null(MacroAssembler *masm, Address adr, const char* message) {
+  __ cmpptr(adr, 0);
+  stop_if(masm, Assembler::zero, message);
+}
+
+MacroAssembler* debug_line(MacroAssembler* masm, int l) {
+  masm->movl(r13, l);
+  return masm;
+}
+
+void create_switchTo_contents(MacroAssembler *masm, int start, OopMapSet* oop_maps, int &stack_slots, int total_in_args,
+                              BasicType *in_sig_bt, VMRegPair *in_regs, BasicType ret_type, bool terminate) {
+  assert(total_in_args == 2, "wrong number of arguments");
+
+  if (j_rarg0 != rsi) {
+    __ movptr(rsi, j_rarg0);
+  }
+  if (j_rarg1 != rdx) {
+    __ movptr(rdx, j_rarg1);
+  }
+
+  // push the current IP and frame pointer onto the stack
+  __ push(rbp);
+
+  Register thread = r15;
+  Register target_coroutine = rdx;
+  // check that we're dealing with sane objects...
+  DEBUG_ONLY(stop_if_null(masm, target_coroutine, "null new_coroutine"));
+  __ movptr(target_coroutine, Address(target_coroutine, java_dyn_CoroutineBase::get_data_offset()));
+  DEBUG_ONLY(stop_if_null(masm, target_coroutine, "new_coroutine without data"));
+
+/*
+#ifdef ASSERT
+#undef __
+#define __ debug_line(masm, __LINE__)->
+#endif
+*/
+  {
+    //////////////////////////////////////////////////////////////////////////
+    // store information into the old coroutine's object
+    //
+    // valid registers: rsi = old Coroutine, rdx = target Coroutine
+
+    Register old_coroutine_obj = rsi;
+    Register old_coroutine = r9;
+    Register old_stack = r10;
+    Register temp = r8;
+
+    // check that we're dealing with sane objects...
+    DEBUG_ONLY(stop_if_null(masm, old_coroutine_obj, "null old_coroutine"));
+    __ movptr(old_coroutine, Address(old_coroutine_obj, java_dyn_CoroutineBase::get_data_offset()));
+    DEBUG_ONLY(stop_if_null(masm, old_coroutine, "old_coroutine without data"));
+    __ movptr(old_stack, Address(old_coroutine, Coroutine::stack_offset()));
+
+#if defined(_WINDOWS)
+    // rescue the SEH pointer
+    __ prefix(Assembler::GS_segment);
+    __ movptr(temp, Address(noreg, 0x00));
+    __ movptr(Address(old_coroutine, Coroutine::last_SEH_offset()), temp);
+#endif
+
+    __ movl(Address(old_coroutine, Coroutine::state_offset()) , Coroutine::_onstack);
+
+    // rescue old handle and resource areas
+    __ movptr(temp, Address(thread, Thread::handle_area_offset()));
+    __ movptr(Address(old_coroutine, Coroutine::handle_area_offset()), temp);
+    __ movptr(temp, Address(thread, Thread::resource_area_offset()));
+    __ movptr(Address(old_coroutine, Coroutine::resource_area_offset()), temp);
+    __ movptr(temp, Address(thread, Thread::last_handle_mark_offset()));
+    __ movptr(Address(old_coroutine, Coroutine::last_handle_mark_offset()), temp);
+    __ movptr(temp, Address(thread, Thread::active_handles_offset()));
+    __ movptr(Address(old_coroutine, Coroutine::active_handles_offset()), temp);
+    __ movptr(temp, Address(thread, Thread::metadata_handles_offset()));
+    __ movptr(Address(old_coroutine, Coroutine::metadata_handles_offset()), temp);
+#ifdef ASSERT
+    __ movl(temp, Address(thread, JavaThread::java_call_counter_offset()));
+    __ movl(Address(old_coroutine, Coroutine::java_call_counter_offset()), temp);
+#endif
+
+    __ movptr(Address(old_stack, CoroutineStack::last_sp_offset()), rsp);
+  }
+  Register target_stack = r12;
+  __ movptr(target_stack, Address(target_coroutine, Coroutine::stack_offset()));
+
+  {
+    //////////////////////////////////////////////////////////////////////////
+    // perform the switch to the new stack
+    //
+    // valid registers: rdx = target Coroutine
+
+    __ movl(Address(target_coroutine, Coroutine::state_offset()), Coroutine::_current);
+
+    Register temp = r8;
+    Register temp2 = r9;
+    {
+      Register thread = r15;
+      __ movptr(Address(thread, JavaThread::current_coroutine_offset()), target_coroutine);
+      // set new handle and resource areas
+      __ movptr(temp, Address(target_coroutine, Coroutine::handle_area_offset()));
+      __ movptr(Address(thread, Thread::handle_area_offset()), temp);
+      __ movptr(temp, Address(target_coroutine, Coroutine::resource_area_offset()));
+      __ movptr(Address(thread, Thread::resource_area_offset()), temp);
+      __ movptr(temp, Address(target_coroutine, Coroutine::last_handle_mark_offset()));
+      __ movptr(Address(thread, Thread::last_handle_mark_offset()), temp);
+      __ movptr(temp, Address(target_coroutine, Coroutine::active_handles_offset()));
+      __ movptr(Address(thread, Thread::active_handles_offset()), temp);
+      __ movptr(temp, Address(target_coroutine, Coroutine::metadata_handles_offset()));
+      __ movptr(Address(thread, Thread::metadata_handles_offset()), temp);
+
+#ifdef ASSERT
+      __ movl(temp, Address(target_coroutine, Coroutine::java_call_counter_offset()));
+      __ movl(Address(thread, JavaThread::java_call_counter_offset()), temp);
+
+      __ movptr(Address(target_coroutine, Coroutine::handle_area_offset()), (intptr_t)NULL_WORD);
+      __ movptr(Address(target_coroutine, Coroutine::resource_area_offset()), (intptr_t)NULL_WORD);
+      __ movptr(Address(target_coroutine, Coroutine::last_handle_mark_offset()), (intptr_t)NULL_WORD);
+      __ movl(Address(target_coroutine, Coroutine::java_call_counter_offset()), 0);
+#endif
+
+      // update the thread's stack base and size
+      __ movptr(temp, Address(target_stack, CoroutineStack::stack_base_offset()));
+      __ movptr(Address(thread, JavaThread::stack_base_offset()), temp);
+      __ movl(temp2, Address(target_stack, CoroutineStack::stack_size_offset()));
+      __ movl(Address(thread, JavaThread::stack_size_offset()), temp2);
+    }
+#if defined(_WINDOWS)
+    {
+      Register tib = rax;
+      // get the linear address of the TIB (thread info block)
+      __ prefix(Assembler::GS_segment);
+      __ movptr(tib, Address(noreg, 0x30));
+
+      // update the TIB stack base and top
+      __ movptr(Address(tib, 0x8), temp);
+      __ subptr(temp, temp2);
+      __ movptr(Address(tib, 0x10), temp);
+
+      // exchange the TIB structured exception handler pointer
+      __ movptr(temp, Address(target_coroutine, Coroutine::last_SEH_offset()));
+      __ movptr(Address(tib, 0), temp);
+    }
+#endif
+    // restore the stack pointer
+    __ movptr(temp, Address(target_stack, CoroutineStack::last_sp_offset()));
+    __ movptr(rsp, temp);
+
+    __ pop(rbp);
+
+    __ int3();
+
+    if (!terminate) {
+      //////////////////////////////////////////////////////////////////////////
+      // normal case (resume immediately)
+
+      // this will reset r12
+      __ reinit_heapbase();
+
+      Label normal;
+      __ lea(rcx, RuntimeAddress((unsigned char*)coroutine_start));
+      __ cmpq(Address(rsp, 0), rcx);
+      __ jcc(Assembler::notEqual, normal);
+
+      __ movq(c_rarg0, Address(rsp, HeapWordSize * 2));
+      __ movq(c_rarg1, Address(rsp, HeapWordSize * 3));
+
+      __ bind(normal);
+
+      __ ret(0);        // <-- this will jump to the stored IP of the target coroutine
+
+    } else {
+      //////////////////////////////////////////////////////////////////////////
+      // slow case (terminate old coroutine)
+
+      // this will reset r12
+      __ reinit_heapbase();
+
+      if (j_rarg0 != rsi) {
+        __ movptr(j_rarg0, rsi);
+      }
+      __ movptr(j_rarg1, 0);
+    }
+  }
 }

--- a/src/hotspot/share/classfile/javaClasses.cpp
+++ b/src/hotspot/share/classfile/javaClasses.cpp
@@ -4721,9 +4721,9 @@ void java_nio_Buffer::compute_offsets() {
 int java_dyn_CoroutineBase::_data_offset = 0;
 
 void java_dyn_CoroutineBase::compute_offsets() {
-  Klass* k = vmClasses::java_dyn_CoroutineBase_klass();
-  if (k != NULL) {
-    compute_offset(_data_offset, InstanceKlass::cast(k), vmSymbols::data_name(), vmSymbols::long_signature());
+  InstanceKlass* ik = vmClasses::java_dyn_CoroutineBase_klass();
+  if (ik != NULL) {
+    compute_offset(_data_offset, ik, vmSymbols::data_name(), vmSymbols::long_signature());
   }
 }
 
@@ -5066,6 +5066,10 @@ void java_lang_InternalError::serialize_offsets(SerializeClosure* f) {
 
 // Compute field offsets of all the classes in this file
 void JavaClasses::compute_offsets() {
+  if (EnableCoroutine) {
+    java_dyn_CoroutineBase::compute_offsets();
+  }
+
   if (UseSharedSpaces) {
     JVMTI_ONLY(assert(JvmtiExport::is_early_phase() && !(JvmtiExport::should_post_class_file_load_hook() &&
                                                          JvmtiExport::has_early_class_hook_env()),
@@ -5081,10 +5085,6 @@ void JavaClasses::compute_offsets() {
   // BASIC_JAVA_CLASSES_DO_PART1 classes (java_lang_String, java_lang_Class and
   // java_lang_ref_Reference) earlier inside vmClasses::resolve_all()
   BASIC_JAVA_CLASSES_DO_PART2(DO_COMPUTE_OFFSETS);
-
-  if (EnableCoroutine) {
-    java_dyn_CoroutineBase::compute_offsets();
-  }
 }
 
 #if INCLUDE_CDS

--- a/src/hotspot/share/classfile/javaClasses.cpp
+++ b/src/hotspot/share/classfile/javaClasses.cpp
@@ -4716,6 +4716,25 @@ void java_nio_Buffer::compute_offsets() {
   BUFFER_FIELDS_DO(FIELD_COMPUTE_OFFSET);
 }
 
+/* stack manipulation */
+
+int java_dyn_CoroutineBase::_data_offset = 0;
+
+void java_dyn_CoroutineBase::compute_offsets() {
+  Klass* k = vmClasses::java_dyn_CoroutineBase_klass();
+  if (k != NULL) {
+    compute_offset(_data_offset, InstanceKlass::cast(k), vmSymbols::data_name(), vmSymbols::long_signature());
+  }
+}
+
+jlong java_dyn_CoroutineBase::data(oop obj) {
+  return obj->long_field(_data_offset);
+}
+
+void java_dyn_CoroutineBase::set_data(oop obj, jlong value) {
+  obj->long_field_put(_data_offset, value);
+}
+
 #if INCLUDE_CDS
 void java_nio_Buffer::serialize_offsets(SerializeClosure* f) {
   BUFFER_FIELDS_DO(FIELD_SERIALIZE_OFFSET);
@@ -5062,6 +5081,10 @@ void JavaClasses::compute_offsets() {
   // BASIC_JAVA_CLASSES_DO_PART1 classes (java_lang_String, java_lang_Class and
   // java_lang_ref_Reference) earlier inside vmClasses::resolve_all()
   BASIC_JAVA_CLASSES_DO_PART2(DO_COMPUTE_OFFSETS);
+
+  if (EnableCoroutine) {
+    java_dyn_CoroutineBase::compute_offsets();
+  }
 }
 
 #if INCLUDE_CDS

--- a/src/hotspot/share/classfile/javaClasses.hpp
+++ b/src/hotspot/share/classfile/javaClasses.hpp
@@ -1782,6 +1782,24 @@ class InjectedField {
   INTERNALERROR_INJECTED_FIELDS(macro)
 
 
+class java_dyn_CoroutineBase: AllStatic {
+private:
+  // Note that to reduce dependencies on the JDK we compute these offsets at run-time.
+  static int _data_offset;
+
+  static void compute_offsets();
+
+public:
+  // Accessors
+  static jlong data(oop obj);
+  static void set_data(oop obj, jlong value);
+
+  static int get_data_offset()    { return _data_offset; }
+
+  // Debugging
+  friend class JavaClasses;
+};
+
 // Interface to hard-coded offset checking
 
 class JavaClasses : AllStatic {

--- a/src/hotspot/share/classfile/vmClassMacros.hpp
+++ b/src/hotspot/share/classfile/vmClassMacros.hpp
@@ -168,6 +168,10 @@
   do_klass(Integer_klass,                               java_lang_Integer                                     ) \
   do_klass(Long_klass,                                  java_lang_Long                                        ) \
                                                                                                                 \
+  /* Stack manipulation classes */                                                                              \
+  do_klass(java_dyn_CoroutineSupport_klass,             java_dyn_CoroutineSupport                             ) \
+  do_klass(java_dyn_CoroutineBase_klass,                java_dyn_CoroutineBase                                ) \
+                                                                                                                \
   /* force inline of iterators */                                                                               \
   do_klass(Iterator_klass,                              java_util_Iterator                                    ) \
                                                                                                                 \

--- a/src/hotspot/share/classfile/vmIntrinsics.hpp
+++ b/src/hotspot/share/classfile/vmIntrinsics.hpp
@@ -942,6 +942,15 @@ class methodHandle;
    do_name(     unpark_name,                                            "unpark")                                              \
    do_alias(    unpark_signature,                                       /*(LObject;)V*/ object_void_signature)                 \
                                                                                                                                \
+  /* coroutine intrinsics */                                                                                            \
+  do_intrinsic(_switchTo,                 java_dyn_CoroutineSupport, switchTo_name, switchTo_signature, F_SN)           \
+   do_name(     switchTo_name,                                    "switchTo")                                           \
+   do_signature(switchTo_signature,                               "(Ljava/dyn/CoroutineBase;Ljava/dyn/CoroutineBase;)V") \
+  do_intrinsic(_switchToAndTerminate,     java_dyn_CoroutineSupport, switchToAndTerminate_name, switchTo_signature, F_SN) \
+   do_name(     switchToAndTerminate_name,                        "switchToAndTerminate")                               \
+  do_intrinsic(_switchToAndExit,          java_dyn_CoroutineSupport, switchToAndExit_name, switchTo_signature, F_SN)    \
+   do_name(     switchToAndExit_name,                             "switchToAndExit")                                    \
+                                                                                                                        \
   do_intrinsic(_StringBuilder_void,   java_lang_StringBuilder, object_initializer_name, void_method_signature,     F_R)   \
   do_intrinsic(_StringBuilder_int,    java_lang_StringBuilder, object_initializer_name, int_void_signature,        F_R)   \
   do_intrinsic(_StringBuilder_String, java_lang_StringBuilder, object_initializer_name, string_void_signature,     F_R)   \

--- a/src/hotspot/share/classfile/vmSymbols.hpp
+++ b/src/hotspot/share/classfile/vmSymbols.hpp
@@ -684,6 +684,21 @@
   template(classRedefinedCount_name,                   "classRedefinedCount")                                     \
   template(classLoader_name,                           "classLoader")                                             \
   template(componentType_name,                         "componentType")                                           \
+  /* coroutine support */                                                                                         \
+  template(java_dyn_CoroutineSupport,                  "java/dyn/CoroutineSupport")                               \
+  template(java_dyn_CoroutineBase,                     "java/dyn/CoroutineBase")                                  \
+  template(java_dyn_CoroutineExitException,            "java/dyn/CoroutineExitException")                         \
+  template(data_name,                                  "data")                                                    \
+  template(stack_name,                                 "stack")                                                   \
+  template(current_name,                               "current")                                                 \
+  template(java_dyn_CoroutineBase_signature,           "Ljava/dyn/CoroutineBase;")                                \
+  template(startInternal_method_name,                  "startInternal")                                           \
+  template(initializeCoroutineSupport_method_name,     "initializeCoroutineSupport")                              \
+  template(bci_name,                                   "bci")                                                     \
+  template(localCount_name,                            "localCount")                                              \
+  template(expressionCount_name,                       "expressionCount")                                         \
+  template(scalarValues_name,                          "scalarValues")                                            \
+  template(objectValues_name,                          "objectValues")                                            \
                                                                                                                   \
   /* forEachRemaining support */                                                                                  \
   template(java_util_stream_StreamsRangeIntSpliterator,          "java/util/stream/Streams$RangeIntSpliterator")  \

--- a/src/hotspot/share/code/nmethod.cpp
+++ b/src/hotspot/share/code/nmethod.cpp
@@ -1380,7 +1380,7 @@ bool nmethod::make_not_entrant_or_zombie(int state) {
     if (intrinsic_id == vmIntrinsics::_switchTo ||
         intrinsic_id == vmIntrinsics::_switchToAndExit ||
         intrinsic_id == vmIntrinsics::_switchToAndTerminate) {
-      assert(method()->constants()->pool_holder() == SystemDictionary::java_dyn_CoroutineSupport_klass(), "wrong method!");
+      assert(method()->constants()->pool_holder() == vmClasses::java_dyn_CoroutineSupport_klass(), "wrong method!");
       assert(state == not_entrant, "wrong state");
       return false;
     }

--- a/src/hotspot/share/code/nmethod.cpp
+++ b/src/hotspot/share/code/nmethod.cpp
@@ -1373,6 +1373,19 @@ void nmethod::unlink_from_method() {
 bool nmethod::make_not_entrant_or_zombie(int state) {
   assert(state == zombie || state == not_entrant, "must be zombie or not_entrant");
 
+  if (EnableCoroutine && method() != NULL) {
+    // do not deal with intrinsic methods of coroutine klass
+    assert(!is_unloaded(), "wrong state");
+    vmIntrinsics::ID intrinsic_id = method()->intrinsic_id();
+    if (intrinsic_id == vmIntrinsics::_switchTo ||
+        intrinsic_id == vmIntrinsics::_switchToAndExit ||
+        intrinsic_id == vmIntrinsics::_switchToAndTerminate) {
+      assert(method()->constants()->pool_holder() == SystemDictionary::java_dyn_CoroutineSupport_klass(), "wrong method!");
+      assert(state == not_entrant, "wrong state");
+      return false;
+    }
+  }
+
   if (Atomic::load(&_state) >= state) {
     // Avoid taking the lock if already in required state.
     // This is safe from races because the state is an end-state,

--- a/src/hotspot/share/prims/jvm.cpp
+++ b/src/hotspot/share/prims/jvm.cpp
@@ -363,19 +363,6 @@ JVM_ENTRY(jobjectArray, JVM_GetProperties(JNIEnv *env))
     ndx++;
   }
 
-  //Convert the -XX:+EnableCoroutine command line flag
-  //to the com.alibaba.coroutine.enableCoroutine property in case that
-  //the java code can determine if the coroutine feature is enabled.
-  {
-    // PUTPROP(props, "com.alibaba.coroutine.enableCoroutine",
-    //     EnableCoroutine ? "true" : "false");
-    Handle key_str = java_lang_String::create_from_platform_dependent_str("com.alibaba.coroutine.enableCoroutine", CHECK_NULL);
-    Handle value_str  = java_lang_String::create_from_platform_dependent_str(EnableCoroutine ? "true" : "false", CHECK_NULL);
-    result_h->obj_at_put(ndx * 2,  key_str());
-    result_h->obj_at_put(ndx * 2 + 1, value_str());
-    ndx++;
-  }
-
   // JVM monitoring and management support
   // Add the sun.management.compiler property for the compiler's name
   {

--- a/src/hotspot/share/prims/nativeLookup.cpp
+++ b/src/hotspot/share/prims/nativeLookup.cpp
@@ -217,6 +217,7 @@ char* NativeLookup::long_jni_name(const methodHandle& method) {
 }
 
 extern "C" {
+  void JNICALL JVM_RegisterCoroutineSupportMethods(JNIEnv* env, jclass corocls);
   void JNICALL JVM_RegisterMethodHandleMethods(JNIEnv *env, jclass unsafecls);
   void JNICALL JVM_RegisterReferencesMethods(JNIEnv *env, jclass unsafecls);
   void JNICALL JVM_RegisterUpcallHandlerMethods(JNIEnv *env, jclass unsafecls);
@@ -243,6 +244,7 @@ static JNINativeMethod lookup_special_native_methods[] = {
   { CC"Java_jdk_internal_foreign_abi_ProgrammableInvoker_registerNatives",      NULL, FN_PTR(JVM_RegisterProgrammableInvokerMethods) },
   { CC"Java_jdk_internal_invoke_NativeEntryPoint_registerNatives",      NULL, FN_PTR(JVM_RegisterNativeEntryPointMethods) },
   { CC"Java_jdk_internal_perf_Perf_registerNatives",               NULL, FN_PTR(JVM_RegisterPerfMethods)         },
+  { CC"Java_java_dyn_CoroutineSupport_registerNatives",            NULL, FN_PTR(JVM_RegisterCoroutineSupportMethods)},
   { CC"Java_sun_hotspot_WhiteBox_registerNatives",                 NULL, FN_PTR(JVM_RegisterWhiteBoxMethods)     },
   { CC"Java_jdk_test_whitebox_WhiteBox_registerNatives",           NULL, FN_PTR(JVM_RegisterWhiteBoxMethods)     },
   { CC"Java_jdk_internal_vm_vector_VectorSupport_registerNatives", NULL, FN_PTR(JVM_RegisterVectorSupportMethods)},
@@ -261,6 +263,10 @@ static address lookup_special_native(const char* jni_name) {
   for (int i = 0; i < count; i++) {
     // NB: To ignore the jni prefix and jni postfix strstr is used matching.
     if (strstr(jni_name, lookup_special_native_methods[i].name) != NULL) {
+      if (!EnableCoroutine && FN_PTR(JVM_RegisterCoroutineSupportMethods) ==
+          lookup_special_native_methods[i].fnPtr) {
+        continue;
+      }
       return CAST_FROM_FN_PTR(address, lookup_special_native_methods[i].fnPtr);
     }
   }

--- a/src/hotspot/share/prims/unsafe.cpp
+++ b/src/hotspot/share/prims/unsafe.cpp
@@ -32,6 +32,7 @@
 #include "classfile/systemDictionary.hpp"
 #include "classfile/vmSymbols.hpp"
 #include "jfr/jfrEvents.hpp"
+#include "compiler/compileBroker.hpp"
 #include "memory/allocation.inline.hpp"
 #include "memory/resourceArea.hpp"
 #include "oops/access.inline.hpp"
@@ -42,9 +43,11 @@
 #include "oops/oop.inline.hpp"
 #include "oops/typeArrayOop.inline.hpp"
 #include "prims/unsafe.hpp"
+#include "runtime/coroutine.hpp"
 #include "runtime/globals.hpp"
 #include "runtime/handles.inline.hpp"
 #include "runtime/interfaceSupport.inline.hpp"
+#include "runtime/java.hpp"
 #include "runtime/jniHandles.inline.hpp"
 #include "runtime/orderAccess.hpp"
 #include "runtime/reflection.hpp"
@@ -870,6 +873,101 @@ UNSAFE_ENTRY(jint, Unsafe_GetLoadAverage0(JNIEnv *env, jobject unsafe, jdoubleAr
   return ret;
 } UNSAFE_END
 
+JVM_ENTRY(jlong, CoroutineSupport_getThreadCoroutine(JNIEnv* env, jclass klass))
+  DEBUG_CORO_PRINT("CoroutineSupport_getThreadCoroutine\n");
+
+  Coroutine* list = thread->coroutine_list();
+  assert(list != NULL, "thread isn't initialized for coroutines");
+
+  return (jlong)list;
+JVM_END
+
+JVM_ENTRY(void, CoroutineSupport_switchTo(JNIEnv* env, jclass klass, jobject old_coroutine, jobject target_coroutine))
+  ShouldNotReachHere();
+JVM_END
+
+JVM_ENTRY(void, CoroutineSupport_switchToAndTerminate(JNIEnv* env, jclass klass, jobject old_coroutine, jobject target_coroutine))
+
+  assert(old_coroutine != NULL, "NULL old CoroutineBase in switchToAndTerminate");
+  assert(target_coroutine == NULL, "expecting NULL");
+
+  oop old_oop = JNIHandles::resolve(old_coroutine);
+  Coroutine* coro = (Coroutine*)java_dyn_CoroutineBase::data(old_oop);
+  assert(coro != NULL, "NULL old coroutine in switchToAndTerminate");
+
+  java_dyn_CoroutineBase::set_data(old_oop, 0);
+
+  CoroutineStack* stack = coro->stack();
+  stack->remove_from_list(thread->coroutine_stack_list());
+  if (thread->coroutine_stack_cache_size() < MaxFreeCoroutinesCacheSize) {
+    stack->insert_into_list(thread->coroutine_stack_cache());
+    thread->coroutine_stack_cache_size() ++;
+  } else {
+    CoroutineStack::free_stack(stack, thread);
+  }
+  delete coro;
+JVM_END
+
+JVM_ENTRY(void, CoroutineSupport_switchToAndExit(JNIEnv* env, jclass klass, jobject old_coroutine, jobject target_coroutine))
+  {
+    THROW(vmSymbols::java_dyn_CoroutineExitException());
+  }
+JVM_END
+
+JVM_ENTRY(jlong, CoroutineSupport_createCoroutine(JNIEnv* env, jclass klass, jobject coroutine, jlong stack_size))
+  DEBUG_CORO_PRINT("CoroutineSupport_createCoroutine\n");
+
+  assert(coroutine != NULL, "cannot create coroutine with NULL Coroutine object");
+
+  if (stack_size == 0 || stack_size < -1) {
+    THROW_MSG_0(vmSymbols::java_lang_IllegalArgumentException(), "invalid stack size");
+  }
+  CoroutineStack* stack = NULL;
+  if (stack_size <= 0 && thread->coroutine_stack_cache_size() > 0) {
+    stack = thread->coroutine_stack_cache();
+    stack->remove_from_list(thread->coroutine_stack_cache());
+    thread->coroutine_stack_cache_size() --;
+    DEBUG_CORO_ONLY(tty->print("reused coroutine stack at %08x\n", stack->_stack_base));
+  } else {
+    stack = CoroutineStack::create_stack(thread, stack_size);
+    if (stack == NULL) {
+      THROW_0(vmSymbols::java_lang_OutOfMemoryError());
+    }
+  }
+  stack->insert_into_list(thread->coroutine_stack_list());
+
+  Coroutine* coro = Coroutine::create_coroutine(thread, stack, JNIHandles::resolve(coroutine));
+  if (coro == NULL) {
+    THROW_0(vmSymbols::java_lang_OutOfMemoryError());
+  }
+  coro->insert_into_list(thread->coroutine_list());
+  return (jlong)coro;
+JVM_END
+
+
+JVM_ENTRY(jboolean, CoroutineSupport_isDisposable(JNIEnv* env, jclass klass, jlong coroutineLong))
+  DEBUG_CORO_PRINT("CoroutineSupport_isDisposable\n");
+  Coroutine* coro = (Coroutine*)coroutineLong;
+  assert(coro != NULL, "cannot free NULL coroutine");
+  assert(!coro->is_thread_coroutine(), "cannot free thread coroutine");
+
+  jboolean is_disposable = coro->is_disposable();
+  if (is_disposable) {
+    CoroutineStack* stack = coro->stack();
+    stack->remove_from_list(thread->coroutine_stack_list());
+    CoroutineStack::free_stack(stack, thread);
+    delete coro;
+  }
+  return is_disposable;
+JVM_END
+
+JVM_ENTRY(jobject, CoroutineSupport_cleanupCoroutine(JNIEnv* env, jclass klass))
+  DEBUG_CORO_PRINT("CoroutineSupport_cleanupCoroutine\n");
+
+  // TODO: implementation needed...
+
+  return NULL;
+JVM_END
 
 /// JVM_RegisterUnsafeMethods
 
@@ -953,6 +1051,22 @@ static JNINativeMethod jdk_internal_misc_Unsafe_methods[] = {
     {CC "fullFence",          CC "()V",                  FN_PTR(Unsafe_FullFence)},
 };
 
+#define COBA "Ljava/dyn/CoroutineBase;"
+
+JNINativeMethod coroutine_support_methods[] = {
+    {CC"getThreadCoroutine",      CC "()J",              FN_PTR(CoroutineSupport_getThreadCoroutine)},
+    {CC"createCoroutine",         CC "(" COBA "J)J",     FN_PTR(CoroutineSupport_createCoroutine)},
+    {CC"isDisposable",            CC "(J)Z",             FN_PTR(CoroutineSupport_isDisposable)},
+    {CC"switchTo",                CC "(" COBA COBA ")V", FN_PTR(CoroutineSupport_switchTo)},
+    {CC"switchToAndTerminate",    CC "(" COBA COBA ")V", FN_PTR(CoroutineSupport_switchToAndTerminate)},
+    {CC"switchToAndExit",         CC "(" COBA COBA ")V", FN_PTR(CoroutineSupport_switchToAndExit)},
+    {CC"cleanupCoroutine",        CC "()" COBA,          FN_PTR(CoroutineSupport_cleanupCoroutine)},
+};
+
+#define COMPILE_CORO_METHODS_FROM (3)
+
+#undef COBA
+
 #undef CC
 #undef FN_PTR
 
@@ -979,3 +1093,30 @@ JVM_ENTRY(void, JVM_RegisterJDKInternalMiscUnsafeMethods(JNIEnv *env, jclass uns
   int ok = env->RegisterNatives(unsafeclass, jdk_internal_misc_Unsafe_methods, sizeof(jdk_internal_misc_Unsafe_methods)/sizeof(JNINativeMethod));
   guarantee(ok == 0, "register jdk.internal.misc.Unsafe natives");
 } JVM_END
+
+JVM_ENTRY(void, JVM_RegisterCoroutineSupportMethods(JNIEnv *env, jclass corocls))
+  {
+    assert(EnableCoroutine, "coroutine not enabled");
+
+    ThreadToNativeFromVM ttnfv(thread);
+    {
+      int coro_method_count = (int)(sizeof(coroutine_support_methods)/sizeof(JNINativeMethod));
+
+      for (int i=0; i<coro_method_count; i++) {
+        env->RegisterNatives(corocls, coroutine_support_methods + i, 1);
+        if (env->ExceptionOccurred()) {
+          tty->print_cr("Warning:  Coroutine classes not found (%i)", i);
+          vm_exit(1);
+        }
+      }
+      for (int i=COMPILE_CORO_METHODS_FROM; i<coro_method_count; i++) {
+        jmethodID id = env->GetStaticMethodID(corocls, coroutine_support_methods[i].name, coroutine_support_methods[i].signature);
+        {
+          ThreadInVMfromNative tivfn(thread);
+          methodHandle method(THREAD, Method::resolve_jmethod_id(id));
+          AdapterHandlerLibrary::create_native_wrapper(method);
+        }
+      }
+    }
+  }
+JVM_END

--- a/src/hotspot/share/prims/unsafe.cpp
+++ b/src/hotspot/share/prims/unsafe.cpp
@@ -32,7 +32,6 @@
 #include "classfile/systemDictionary.hpp"
 #include "classfile/vmSymbols.hpp"
 #include "jfr/jfrEvents.hpp"
-#include "compiler/compileBroker.hpp"
 #include "memory/allocation.inline.hpp"
 #include "memory/resourceArea.hpp"
 #include "oops/access.inline.hpp"

--- a/src/hotspot/share/runtime/arguments.cpp
+++ b/src/hotspot/share/runtime/arguments.cpp
@@ -438,6 +438,13 @@ void Arguments::init_version_specific_system_properties() {
       new SystemProperty("java.vm.vendor", VM_Version::vm_vendor(),  false));
 }
 
+void Arguments::init_wisp_system_properties() {
+  // Convert coroutine flags to props to make java side aware of them.
+  PropertyList_add(&_system_properties,
+    new SystemProperty("com.alibaba.coroutine.enableCoroutine",
+      EnableCoroutine ? "true" : "false",  false));
+}
+
 /*
  *  -XX argument processing:
  *

--- a/src/hotspot/share/runtime/arguments.hpp
+++ b/src/hotspot/share/runtime/arguments.hpp
@@ -559,6 +559,10 @@ class Arguments : AllStatic {
   // Update/Initialize System properties after JDK version number is known
   static void init_version_specific_system_properties();
 
+  // Initialize Coroutine and Wisp properties
+  // Must be called after arguments parsing
+  static void init_wisp_system_properties();
+
   // Update VM info property - called after argument parsing
   static void update_vm_info_property(const char* vm_info) {
     _vm_info->set_value(vm_info);

--- a/src/hotspot/share/runtime/coroutine.cpp
+++ b/src/hotspot/share/runtime/coroutine.cpp
@@ -1,0 +1,363 @@
+/*
+ * Copyright 2001-2010 Sun Microsystems, Inc.  All Rights Reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Sun Microsystems, Inc., 4150 Network Circle, Santa Clara,
+ * CA 95054 USA or visit www.sun.com if you need additional information or
+ * have any questions.
+ *
+ */
+
+#include "precompiled.hpp"
+#include "classfile/vmSymbols.hpp"
+#include "runtime/coroutine.hpp"
+#include "runtime/globals.hpp"
+#include "runtime/handles.inline.hpp"
+#include "runtime/javaCalls.hpp"
+#include "runtime/os.inline.hpp"
+#include "runtime/stackFrameStream.inline.hpp"
+#include "runtime/thread.inline.hpp"
+#ifdef TARGET_ARCH_x86
+# include "vmreg_x86.inline.hpp"
+#endif
+#ifdef TARGET_ARCH_sparc
+# include "vmreg_sparc.inline.hpp"
+#endif
+#ifdef TARGET_ARCH_zero
+# include "vmreg_zero.inline.hpp"
+#endif
+#include "jniHandles.inline.hpp"
+
+#ifdef _WINDOWS
+
+LONG WINAPI topLevelExceptionFilter(struct _EXCEPTION_POINTERS* exceptionInfo);
+
+
+void coroutine_start(Coroutine* coroutine, jobject coroutineObj) {
+  coroutine->thread()->set_thread_state(_thread_in_vm);
+
+  if (UseVectoredExceptions) {
+    // If we are using vectored exception we don't need to set a SEH
+    coroutine->run(coroutineObj);
+  }
+  else {
+    // Install a win32 structured exception handler around every thread created
+    // by VM, so VM can genrate error dump when an exception occurred in non-
+    // Java thread (e.g. VM thread).
+    __try {
+       coroutine->run(coroutineObj);
+    } __except(topLevelExceptionFilter((_EXCEPTION_POINTERS*)_exception_info())) {
+    }
+  }
+
+  ShouldNotReachHere();
+}
+#endif
+
+#if defined(LINUX) || defined(_ALLBSD_SOURCE)
+
+void coroutine_start(Coroutine* coroutine, jobject coroutineObj) {
+  coroutine->thread()->set_thread_state(_thread_in_vm);
+
+  coroutine->run(coroutineObj);
+  ShouldNotReachHere();
+}
+#endif
+
+void Coroutine::run(jobject coroutine) {
+
+  // do not call JavaThread::current() here!
+
+  _thread->set_resource_area(new (mtThread) ResourceArea(32));
+  _thread->set_handle_area(new (mtThread) HandleArea(NULL, 32));
+  _thread->set_metadata_handles(new (ResourceObj::C_HEAP, mtClass) GrowableArray<Metadata*>(30, mtClass));
+
+  {
+    HandleMark hm(_thread);
+    HandleMark hm2(_thread);
+    Handle obj(_thread, JNIHandles::resolve(coroutine));
+    JNIHandles::destroy_global(coroutine);
+    JavaValue result(T_VOID);
+    JavaCalls::call_virtual(&result,
+                            obj,
+                            vmClasses::java_dyn_CoroutineBase_klass(),
+                            vmSymbols::startInternal_method_name(),
+                            vmSymbols::void_method_signature(),
+                            _thread);
+  }
+}
+
+Coroutine* Coroutine::create_thread_coroutine(JavaThread* thread, CoroutineStack* stack) {
+  Coroutine* coro = new Coroutine();
+  if (coro == NULL)
+    return NULL;
+
+  coro->_state = _current;
+  coro->_is_thread_coroutine = true;
+  coro->_thread = thread;
+  coro->_stack = stack;
+  coro->_resource_area = NULL;
+  coro->_handle_area = NULL;
+  coro->_last_handle_mark = NULL;
+  coro->_active_handles = thread->active_handles();
+  coro->_metadata_handles = NULL;
+  coro->_java_call_counter = 0;
+#if defined(_WINDOWS)
+  coro->_last_SEH = NULL;
+#endif
+  return coro;
+}
+
+Coroutine* Coroutine::create_coroutine(JavaThread* thread, CoroutineStack* stack, oop coroutineObj) {
+  Coroutine* coro = new Coroutine();
+  if (coro == NULL) {
+    return NULL;
+  }
+  intptr_t** d = (intptr_t**)stack->stack_base();
+  *(--d) = NULL;
+  jobject obj = JNIHandles::make_global(Handle(thread, coroutineObj));
+  *(--d) = (intptr_t*)obj;
+  *(--d) = (intptr_t*)coro;
+  *(--d) = NULL;
+  *(--d) = (intptr_t*)coroutine_start;
+  *(--d) = NULL;
+
+  stack->set_last_sp((address) d);
+
+  coro->_state = _created;
+  coro->_is_thread_coroutine = false;
+  coro->_thread = thread;
+  coro->_stack = stack;
+  coro->_resource_area = NULL;
+  coro->_handle_area = NULL;
+  coro->_last_handle_mark = NULL;
+  coro->_active_handles = thread->active_handles();
+  coro->_metadata_handles = NULL;
+  coro->_java_call_counter = 0;
+#if defined(_WINDOWS)
+  coro->_last_SEH = NULL;
+#endif
+  return coro;
+}
+
+Coroutine::~Coroutine() {
+  remove_from_list(_thread->coroutine_list());
+  if (!_is_thread_coroutine && _state != Coroutine::_created) {
+    assert(_resource_area != NULL, "_resource_area is NULL");
+    assert(_handle_area != NULL, "_handle_area is NULL");
+    assert(_metadata_handles != NULL, "_metadata_handles is NULL");
+    delete _resource_area;
+    delete _handle_area;
+    delete _metadata_handles;
+    JNIHandleBlock::release_block(active_handles(), _thread);
+    //allocated from JavaCalls::call_virtual during coroutine's first running
+  }
+}
+
+void Coroutine::frames_do(FrameClosure* fc) {
+  switch (_state) {
+    case Coroutine::_created:
+      // the coroutine has never been run
+      break;
+    case Coroutine::_current:
+      // the contents of this coroutine have already been visited
+      break;
+    case Coroutine::_onstack:
+      _stack->frames_do(fc);
+      break;
+    case Coroutine::_dead:
+      // coroutine is dead, ignore
+      break;
+    default:
+      ShouldNotReachHere();
+      break;
+    }
+}
+
+class oops_do_Closure: public FrameClosure {
+private:
+  OopClosure* _f;
+  CodeBlobClosure* _cf;
+public:
+  oops_do_Closure(OopClosure* f, CodeBlobClosure* cf): _f(f), _cf(cf) { }
+  void frames_do(frame* fr, RegisterMap* map) { fr->oops_do(_f, _cf, map); }
+};
+
+void Coroutine::oops_do(OopClosure* f, CodeBlobClosure* cf) {
+  oops_do_Closure fc(f, cf);
+  frames_do(&fc);
+  if (_state == _onstack &&_handle_area != NULL) {
+    DEBUG_CORO_ONLY(tty->print_cr("collecting handle area %08x", _handle_area));
+    _handle_area->oops_do(f);
+    _active_handles->oops_do(f);
+  }
+}
+
+class nmethods_do_Closure: public FrameClosure {
+private:
+  CodeBlobClosure* _cf;
+public:
+  nmethods_do_Closure(CodeBlobClosure* cf): _cf(cf) { }
+  void frames_do(frame* fr, RegisterMap* map) { fr->nmethods_do(_cf); }
+};
+
+void Coroutine::nmethods_do(CodeBlobClosure* cf) {
+  nmethods_do_Closure fc(cf);
+  frames_do(&fc);
+}
+
+class metadata_do_Closure: public FrameClosure {
+private:
+  MetadataClosure* _f;
+public:
+  metadata_do_Closure(MetadataClosure* f): _f(f) { }
+  void frames_do(frame* fr, RegisterMap* map) { fr->metadata_do(_f); }
+};
+
+void Coroutine::metadata_do(MetadataClosure* f) {
+  if (metadata_handles() != NULL) {
+    for (int i = 0; i< metadata_handles()->length(); i++) {
+      f->do_metadata(metadata_handles()->at(i));
+    }
+  }
+  metadata_do_Closure fc(f);
+  frames_do(&fc);
+}
+
+class frames_do_Closure: public FrameClosure {
+private:
+  void (*_f)(frame*, const RegisterMap*);
+public:
+  frames_do_Closure(void f(frame*, const RegisterMap*)): _f(f) { }
+  void frames_do(frame* fr, RegisterMap* map) { _f(fr, map); }
+};
+
+void Coroutine::frames_do(void f(frame*, const RegisterMap* map)) {
+  frames_do_Closure fc(f);
+  frames_do(&fc);
+}
+
+bool Coroutine::is_disposable() {
+  //_handle_area == NULL indicates this coroutine has not been initialized,
+  //we should delete it directly.
+  return _handle_area == NULL;
+}
+
+
+CoroutineStack* CoroutineStack::create_thread_stack(JavaThread* thread) {
+  CoroutineStack* stack = new CoroutineStack(0);
+  if (stack == NULL)
+    return NULL;
+
+  stack->_thread = thread;
+  stack->_is_thread_stack = true;
+  stack->_stack_base = thread->stack_base();
+  stack->_stack_size = thread->stack_size();
+  stack->_last_sp = NULL;
+  stack->_default_size = false;
+  return stack;
+}
+
+CoroutineStack* CoroutineStack::create_stack(JavaThread* thread, intptr_t size/* = -1*/) {
+  bool default_size = false;
+  if (size <= 0) {
+    size = DefaultCoroutineStackSize;
+    default_size = true;
+  }
+
+  uint reserved_pages = StackShadowPages + StackRedPages + StackYellowPages;
+  uintx real_stack_size = size + (reserved_pages * os::vm_page_size());
+  uintx reserved_size = align_up(real_stack_size, os::vm_allocation_granularity());
+
+  CoroutineStack* stack = new CoroutineStack(reserved_size);
+  if (stack == NULL)
+    return NULL;
+  if (!stack->_virtual_space.initialize(stack->_reserved_space, real_stack_size)) {
+    stack->_reserved_space.release();
+    delete stack;
+    return NULL;
+  }
+
+  stack->_thread = thread;
+  stack->_is_thread_stack = false;
+  stack->_stack_base = (address)stack->_virtual_space.high();
+  stack->_stack_size = stack->_virtual_space.committed_size();
+  stack->_last_sp = NULL;
+  stack->_default_size = default_size;
+
+  if (os::uses_stack_guard_pages()) {
+    address low_addr = stack->stack_base() - stack->stack_size();
+    size_t len = (StackYellowPages + StackRedPages) * os::vm_page_size();
+
+    bool allocate = os::must_commit_stack_guard_pages();
+
+    if (!os::guard_memory((char *) low_addr, len)) {
+      warning("Attempt to protect stack guard pages failed.");
+      if (os::uncommit_memory((char *) low_addr, len)) {
+        warning("Attempt to deallocate stack guard pages failed.");
+      }
+    }
+  }
+
+  DEBUG_CORO_ONLY(tty->print("created coroutine stack at %08x with stack size %i (real size: %i)\n", stack->_stack_base, size, stack->_stack_size));
+  return stack;
+}
+
+void CoroutineStack::free_stack(CoroutineStack* stack, JavaThread* thread) {
+  if (stack->is_thread_stack()) {
+    delete stack;
+    return;
+  }
+
+  if (stack->_reserved_space.size() > 0) {
+    stack->_virtual_space.release();
+    stack->_reserved_space.release();
+  }
+  delete stack;
+}
+
+void CoroutineStack::frames_do(FrameClosure* fc) {
+  assert(_last_sp != NULL, "CoroutineStack with NULL last_sp");
+
+  DEBUG_CORO_ONLY(tty->print_cr("frames_do stack %08x", _stack_base));
+
+  intptr_t* fp = ((intptr_t**)_last_sp)[0];
+  if (fp != NULL) {
+    address pc = ((address*)_last_sp)[1];
+    intptr_t* sp = ((intptr_t*)_last_sp) + 2;
+
+    frame fr(sp, fp, pc);
+    StackFrameStream fst(_thread, fr, true, true);
+    fst.register_map()->set_location(rbp->as_VMReg(), (address)_last_sp);
+    fst.register_map()->set_include_argument_oops(false);
+    for(; !fst.is_done(); fst.next()) {
+      fc->frames_do(fst.current(), fst.register_map());
+    }
+  }
+}
+
+frame CoroutineStack::last_frame(Coroutine* coro, RegisterMap& map) const {
+  DEBUG_CORO_ONLY(tty->print_cr("last_frame CoroutineStack"));
+
+  intptr_t* fp = ((intptr_t**)_last_sp)[0];
+  assert(fp != NULL, "coroutine with NULL fp");
+
+  address pc = ((address*)_last_sp)[1];
+  intptr_t* sp = ((intptr_t*)_last_sp) + 2;
+
+  return frame(sp, fp, pc);
+}

--- a/src/hotspot/share/runtime/coroutine.hpp
+++ b/src/hotspot/share/runtime/coroutine.hpp
@@ -1,0 +1,253 @@
+/*
+ * Copyright 1999-2010 Sun Microsystems, Inc.  All Rights Reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Sun Microsystems, Inc., 4150 Network Circle, Santa Clara,
+ * CA 95054 USA or visit www.sun.com if you need additional information or
+ * have any questions.
+ *
+ */
+
+#ifndef SHARE_VM_RUNTIME_COROUTINE_HPP
+#define SHARE_VM_RUNTIME_COROUTINE_HPP
+
+#include "runtime/jniHandles.hpp"
+#include "runtime/handles.hpp"
+#include "memory/allocation.hpp"
+#include "memory/resourceArea.hpp"
+#include "memory/virtualspace.hpp"
+#include "runtime/javaFrameAnchor.hpp"
+#include "runtime/monitorChunk.hpp"
+
+// number of heap words that prepareSwitch will add as a safety measure to the CoroutineData size
+#define COROUTINE_DATA_OVERSIZE (64)
+
+//#define DEBUG_COROUTINES
+
+#ifdef DEBUG_COROUTINES
+#define DEBUG_CORO_ONLY(x) x
+#define DEBUG_CORO_PRINT(x) tty->print(x)
+#else
+#define DEBUG_CORO_ONLY(x)
+#define DEBUG_CORO_PRINT(x)
+#endif
+
+class Coroutine;
+class CoroutineStack;
+
+
+template<class T>
+class DoublyLinkedList {
+private:
+  T*  _last;
+  T*  _next;
+
+public:
+  DoublyLinkedList() {
+    _last = NULL;
+    _next = NULL;
+  }
+
+  typedef T* pointer;
+
+  void remove_from_list(pointer& list);
+  void insert_into_list(pointer& list);
+
+  T* last() const   { return _last; }
+  T* next() const   { return _next; }
+};
+
+class FrameClosure: public StackObj {
+public:
+  virtual void frames_do(frame* fr, RegisterMap* map) = 0;
+};
+
+
+class Coroutine: public CHeapObj<mtThread>, public DoublyLinkedList<Coroutine> {
+public:
+  enum CoroutineState {
+    _created    = 0x00000000,      // not inited
+    _onstack    = 0x00000001,
+    _current    = 0x00000002,
+    _dead       = 0x00000003,      // TODO is this really needed?
+    _dummy      = 0xffffffff
+  };
+
+private:
+  CoroutineState  _state;
+
+  bool            _is_thread_coroutine;
+
+  JavaThread*     _thread;
+  CoroutineStack* _stack;
+
+  ResourceArea*   _resource_area;
+  HandleArea*     _handle_area;
+  HandleMark*     _last_handle_mark;
+  JNIHandleBlock* _active_handles;
+  GrowableArray<Metadata*>* _metadata_handles;
+  int             _java_call_counter;
+
+#ifdef _LP64
+  intptr_t        _storage[2];
+#endif
+
+  // objects of this type can only be created via static functions
+  Coroutine() { }
+
+  void frames_do(FrameClosure* fc);
+
+public:
+  virtual ~Coroutine();
+
+  void run(jobject coroutine);
+
+  static Coroutine* create_thread_coroutine(JavaThread* thread, CoroutineStack* stack);
+  static Coroutine* create_coroutine(JavaThread* thread, CoroutineStack* stack, oop coroutineObj);
+
+  CoroutineState state() const      { return _state; }
+  void set_state(CoroutineState x)  { _state = x; }
+
+  bool is_thread_coroutine() const  { return _is_thread_coroutine; }
+
+  JavaThread* thread() const        { return _thread; }
+  void set_thread(JavaThread* x)    { _thread = x; }
+
+  CoroutineStack* stack() const     { return _stack; }
+
+  ResourceArea* resource_area() const     { return _resource_area; }
+  void set_resource_area(ResourceArea* x) { _resource_area = x; }
+
+  HandleArea* handle_area() const         { return _handle_area; }
+  void set_handle_area(HandleArea* x)     { _handle_area = x; }
+
+  HandleMark* last_handle_mark() const    { return _last_handle_mark; }
+  void set_last_handle_mark(HandleMark* x){ _last_handle_mark = x; }
+
+  JNIHandleBlock* active_handles() const         { return _active_handles; }
+  void set_active_handles(JNIHandleBlock* block) { _active_handles = block; }
+
+  GrowableArray<Metadata*>* metadata_handles() const          { return _metadata_handles; }
+  void set_metadata_handles(GrowableArray<Metadata*>* handles){ _metadata_handles = handles; }
+
+  int java_call_counter() const           { return _java_call_counter; }
+  void set_java_call_counter(int x)       { _java_call_counter = x; }
+
+  bool is_disposable();
+
+  // GC support
+  void oops_do(OopClosure* f, CodeBlobClosure* cf);
+  void nmethods_do(CodeBlobClosure* cf);
+  void metadata_do(MetadataClosure* f);
+  void frames_do(void f(frame*, const RegisterMap* map));
+
+  static ByteSize state_offset()              { return byte_offset_of(Coroutine, _state); }
+  static ByteSize stack_offset()              { return byte_offset_of(Coroutine, _stack); }
+
+  static ByteSize resource_area_offset()      { return byte_offset_of(Coroutine, _resource_area); }
+  static ByteSize handle_area_offset()        { return byte_offset_of(Coroutine, _handle_area); }
+  static ByteSize last_handle_mark_offset()   { return byte_offset_of(Coroutine, _last_handle_mark); }
+  static ByteSize active_handles_offset()     { return byte_offset_of(Coroutine, _active_handles); }
+  static ByteSize metadata_handles_offset()   { return byte_offset_of(Coroutine, _metadata_handles); }
+#ifdef ASSERT
+  static ByteSize java_call_counter_offset()  { return byte_offset_of(Coroutine, _java_call_counter); }
+#endif
+
+#ifdef _LP64
+  static ByteSize storage_offset()            { return byte_offset_of(Coroutine, _storage); }
+#endif
+
+#if defined(_WINDOWS)
+private:
+  address _last_SEH;
+public:
+  static ByteSize last_SEH_offset()           { return byte_offset_of(Coroutine, _last_SEH); }
+#endif
+};
+
+class CoroutineStack: public CHeapObj<mtThread>, public DoublyLinkedList<CoroutineStack> {
+private:
+  JavaThread*     _thread;
+
+  bool            _is_thread_stack;
+  ReservedSpace   _reserved_space;
+  VirtualSpace    _virtual_space;
+
+  address         _stack_base;
+  intptr_t        _stack_size;
+  bool            _default_size;
+
+  address         _last_sp;
+
+  // objects of this type can only be created via static functions
+  CoroutineStack(intptr_t size) : _reserved_space(size) { }
+  virtual ~CoroutineStack() { }
+
+public:
+  static CoroutineStack* create_thread_stack(JavaThread* thread);
+  static CoroutineStack* create_stack(JavaThread* thread, intptr_t size = -1);
+  static void free_stack(CoroutineStack* stack, JavaThread* THREAD);
+
+  static intptr_t get_start_method();
+
+  JavaThread* thread() const                { return _thread; }
+  bool is_thread_stack() const              { return _is_thread_stack; }
+
+  address last_sp() const                   { return _last_sp; }
+  void set_last_sp(address x)               { _last_sp = x; }
+
+  address stack_base() const                { return _stack_base; }
+  intptr_t stack_size() const               { return _stack_size; }
+  bool is_default_size() const              { return _default_size; }
+
+  frame last_frame(Coroutine* coro, RegisterMap& map) const;
+
+  // GC support
+  void frames_do(FrameClosure* fc);
+
+  static ByteSize stack_base_offset()         { return byte_offset_of(CoroutineStack, _stack_base); }
+  static ByteSize stack_size_offset()         { return byte_offset_of(CoroutineStack, _stack_size); }
+  static ByteSize last_sp_offset()            { return byte_offset_of(CoroutineStack, _last_sp); }
+};
+
+template<class T> void DoublyLinkedList<T>::remove_from_list(pointer& list) {
+  if (list == this) {
+    if (list->_next == list)
+      list = NULL;
+    else
+      list = list->_next;
+  }
+  _last->_next = _next;
+  _next->_last = _last;
+  _last = NULL;
+  _next = NULL;
+}
+
+template<class T> void DoublyLinkedList<T>::insert_into_list(pointer& list) {
+  if (list == NULL) {
+    _next = (T*)this;
+    _last = (T*)this;
+    list = (T*)this;
+  } else {
+    _next = list->_next;
+    list->_next = (T*)this;
+    _last = list;
+    _next->_last = (T*)this;
+  }
+}
+
+#endif // SHARE_VM_RUNTIME_COROUTINE_HPP

--- a/src/hotspot/share/runtime/frame.cpp
+++ b/src/hotspot/share/runtime/frame.cpp
@@ -1251,11 +1251,6 @@ void FrameValues::describe(int owner, intptr_t* location, const char* descriptio
   _values.append(fv);
 }
 
-StackFrameStream::StackFrameStream(JavaThread *thread, frame last_frame, bool update) : _reg_map(thread, update) {
-  assert(EnableCoroutine, "EnableCoroutine is off");
-  _fr = last_frame;
-  _is_done = false;
-}
 
 #ifdef ASSERT
 void FrameValues::validate() {

--- a/src/hotspot/share/runtime/frame.cpp
+++ b/src/hotspot/share/runtime/frame.cpp
@@ -1251,6 +1251,11 @@ void FrameValues::describe(int owner, intptr_t* location, const char* descriptio
   _values.append(fv);
 }
 
+StackFrameStream::StackFrameStream(JavaThread *thread, frame last_frame, bool update) : _reg_map(thread, update) {
+  assert(EnableCoroutine, "EnableCoroutine is off");
+  _fr = last_frame;
+  _is_done = false;
+}
 
 #ifdef ASSERT
 void FrameValues::validate() {

--- a/src/hotspot/share/runtime/globals.hpp
+++ b/src/hotspot/share/runtime/globals.hpp
@@ -2085,8 +2085,19 @@ const intx ObjectAlignmentInBytes = 8;
              "Mark all threads after a safepoint, and clear on a modify "   \
              "fence. Add cleanliness checks.")                              \
                                                                             \
-  develop(bool, TraceOptimizedUpcallStubs, false,                              \
-                "Trace optimized upcall stub generation")                      \
+  develop(bool, TraceOptimizedUpcallStubs, false,                           \
+                "Trace optimized upcall stub generation")                   \
+                                                                            \
+  /* Wisp2 */                                                               \
+  product(bool, EnableCoroutine, false,                                     \
+          "Enable coroutine support")                                       \
+                                                                            \
+  product(uintx, DefaultCoroutineStackSize, 128*K,                          \
+          "Default size of stack that is associated with new coroutine")    \
+                                                                            \
+  product(uintx, MaxFreeCoroutinesCacheSize, 20,                            \
+          "The max number of free coroutine stacks a thread can keep")      \
+
 
 // end of RUNTIME_FLAGS
 

--- a/src/hotspot/share/runtime/handles.cpp
+++ b/src/hotspot/share/runtime/handles.cpp
@@ -145,7 +145,6 @@ HandleMark::HandleMark(Thread* thread, HandleArea* area, HandleMark* last_handle
   NOT_PRODUCT(_size_in_bytes = _area->_size_in_bytes;)
   debug_only(_area->_handle_mark_nesting++);
   assert(_area->_handle_mark_nesting > 0, "must stack allocate HandleMarks");
-  debug_only(Atomic::inc(&_nof_handlemarks);)
 
   // Link this in the thread
   set_previous_handle_mark(last_handle_mark);

--- a/src/hotspot/share/runtime/handles.cpp
+++ b/src/hotspot/share/runtime/handles.cpp
@@ -133,6 +133,24 @@ void HandleMark::initialize(Thread* thread) {
   thread->set_last_handle_mark(this);
 }
 
+HandleMark::HandleMark(Thread* thread, HandleArea* area, HandleMark* last_handle_mark) {
+  assert(EnableCoroutine, "EnableCoroutine is off");
+  _thread = thread;
+  // Save area
+  _area  = area;
+  // Save current top
+  _chunk = _area->_chunk;
+  _hwm   = _area->_hwm;
+  _max   = _area->_max;
+  NOT_PRODUCT(_size_in_bytes = _area->_size_in_bytes;)
+  debug_only(_area->_handle_mark_nesting++);
+  assert(_area->_handle_mark_nesting > 0, "must stack allocate HandleMarks");
+  debug_only(Atomic::inc(&_nof_handlemarks);)
+
+  // Link this in the thread
+  set_previous_handle_mark(last_handle_mark);
+}
+
 HandleMark::~HandleMark() {
   assert(_area == _thread->handle_area(), "sanity check");
   assert(_area->_handle_mark_nesting > 0, "must stack allocate HandleMarks" );

--- a/src/hotspot/share/runtime/handles.hpp
+++ b/src/hotspot/share/runtime/handles.hpp
@@ -188,6 +188,13 @@ class HandleArea: public Arena {
     debug_only(_no_handle_mark_nesting = 0);
     _prev = prev;
   }
+  // Only coroutine uses this constructor
+  HandleArea(HandleArea* prev, size_t init_size) : Arena(mtThread, init_size) {
+    assert(EnableCoroutine, "EnableCoroutine is off");
+    debug_only(_handle_mark_nesting    = 0);
+    debug_only(_no_handle_mark_nesting = 0);
+    _prev = prev;
+  }
 
   // Handle allocation
  private:
@@ -258,6 +265,7 @@ class HandleMark {
   void chop_later_chunks();
  public:
   HandleMark(Thread* thread)                      { initialize(thread); }
+  HandleMark(Thread* thread, HandleArea* area, HandleMark* last_handle_mark);
   ~HandleMark();
 
   // Functions used by HandleMarkCleaner

--- a/src/hotspot/share/runtime/javaCalls.cpp
+++ b/src/hotspot/share/runtime/javaCalls.cpp
@@ -112,6 +112,15 @@ JavaCallWrapper::JavaCallWrapper(const methodHandle& callee_method, Handle recei
   MACOS_AARCH64_ONLY(_thread->enable_wx(WXExec));
 }
 
+void JavaCallWrapper::initialize(JavaThread* thread, JNIHandleBlock* handles, Method* callee_method, oop receiver, JavaValue* result) {
+  assert(EnableCoroutine, "EnableCoroutine is off");
+  _thread = thread;
+  _handles = handles;
+  _callee_method = callee_method;
+  _receiver = receiver;
+  _result = result;
+  _anchor.clear();
+}
 
 JavaCallWrapper::~JavaCallWrapper() {
   assert(_thread == JavaThread::current(), "must still be the same thread");

--- a/src/hotspot/share/runtime/javaCalls.hpp
+++ b/src/hotspot/share/runtime/javaCalls.hpp
@@ -56,6 +56,8 @@ class JavaCallWrapper: StackObj {
    JavaCallWrapper(const methodHandle& callee_method, Handle receiver, JavaValue* result, TRAPS);
   ~JavaCallWrapper();
 
+  void initialize(JavaThread* thread, JNIHandleBlock* handles, Method* callee_method, oop receiver, JavaValue* result);
+
   // Accessors
   JavaThread*      thread() const           { return _thread; }
   JNIHandleBlock*  handles() const          { return _handles; }

--- a/src/hotspot/share/runtime/stackFrameStream.cpp
+++ b/src/hotspot/share/runtime/stackFrameStream.cpp
@@ -32,3 +32,9 @@ StackFrameStream::StackFrameStream(JavaThread *thread, bool update, bool process
   _is_done = false;
 }
 
+StackFrameStream::StackFrameStream(JavaThread *thread, frame last_frame, bool update, bool process_frames) : _reg_map(thread, update, process_frames) {
+  assert(EnableCoroutine, "EnableCoroutine is off");
+  _fr = last_frame;
+  _is_done = false;
+}
+

--- a/src/hotspot/share/runtime/stackFrameStream.hpp
+++ b/src/hotspot/share/runtime/stackFrameStream.hpp
@@ -57,6 +57,7 @@ class StackFrameStream : public StackObj {
   bool        _is_done;
  public:
   StackFrameStream(JavaThread *thread, bool update, bool process_frames);
+  StackFrameStream(JavaThread *thread, frame last_frame, bool update, bool process_frames);
 
   // Iteration
   inline bool is_done();

--- a/src/hotspot/share/runtime/thread.hpp
+++ b/src/hotspot/share/runtime/thread.hpp
@@ -91,6 +91,9 @@ class WorkerThread;
 
 class JavaThread;
 
+class Coroutine;
+class CoroutineStack;
+
 // Class hierarchy
 // - Thread
 //   - JavaThread
@@ -606,10 +609,16 @@ protected:
   void leaving_jvmti_env_iteration()             { --_jvmti_env_iteration_count; }
   bool is_inside_jvmti_env_iteration()           { return _jvmti_env_iteration_count > 0; }
 
+  // Coroutine
+  static ByteSize resource_area_offset()         { return byte_offset_of(Thread, _resource_area); }
+  static ByteSize handle_area_offset()           { return byte_offset_of(Thread, _handle_area); }
+  static ByteSize last_handle_mark_offset()      { return byte_offset_of(Thread, _last_handle_mark); }
+
   // Code generation
   static ByteSize exception_file_offset()        { return byte_offset_of(Thread, _exception_file); }
   static ByteSize exception_line_offset()        { return byte_offset_of(Thread, _exception_line); }
   static ByteSize active_handles_offset()        { return byte_offset_of(Thread, _active_handles); }
+  static ByteSize metadata_handles_offset()      { return byte_offset_of(Thread, _metadata_handles); }
 
   static ByteSize stack_base_offset()            { return byte_offset_of(Thread, _stack_base); }
   static ByteSize stack_size_offset()            { return byte_offset_of(Thread, _stack_size); }
@@ -1027,6 +1036,29 @@ class JavaThread: public Thread {
   // failed reallocations.
   int _frames_to_pop_failed_realloc;
 
+  // coroutine support
+  CoroutineStack*   _coroutine_stack_cache;
+  uintx             _coroutine_stack_cache_size;
+  CoroutineStack*   _coroutine_stack_list;
+  Coroutine*        _coroutine_list;
+  Coroutine*        _current_coroutine;
+
+  intptr_t          _coroutine_temp;
+
+ public:
+  CoroutineStack*& coroutine_stack_cache()       { return _coroutine_stack_cache; }
+  uintx& coroutine_stack_cache_size()            { return _coroutine_stack_cache_size; }
+  CoroutineStack*& coroutine_stack_list()        { return _coroutine_stack_list; }
+  Coroutine*& coroutine_list()                   { return _coroutine_list; }
+  Coroutine* current_coroutine()                 { return _current_coroutine; }
+
+  static ByteSize coroutine_temp_offset()        { return byte_offset_of(JavaThread, _coroutine_temp); }
+  static ByteSize current_coroutine_offset()     { return byte_offset_of(JavaThread, _current_coroutine); }
+
+  void initialize_coroutine_support();
+
+ private:
+
   friend class VMThread;
   friend class ThreadWaitTransition;
   friend class VM_Exit;
@@ -1315,6 +1347,9 @@ class JavaThread: public Thread {
   }
 
   static ByteSize suspend_flags_offset()         { return byte_offset_of(JavaThread, _suspend_flags); }
+#ifdef ASSERT
+  static ByteSize java_call_counter_offset()     { return byte_offset_of(JavaThread, _java_call_counter); }
+#endif
 
   static ByteSize do_not_unlock_if_synchronized_offset() { return byte_offset_of(JavaThread, _do_not_unlock_if_synchronized); }
   static ByteSize should_post_on_exceptions_flag_offset() {

--- a/src/java.base/share/classes/java/dyn/Coroutine.java
+++ b/src/java.base/share/classes/java/dyn/Coroutine.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright (c) 2010, 2012, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package java.dyn;
+
+/**
+ * Implementation of symmetric coroutines. A Coroutine will take part in thread-wide scheduling of coroutines. It transfers control to
+ * the next coroutine whenever yield is called.
+ * <p>
+ * Similar to {@link Thread} there are two ways to implement a Coroutine: either by implementing a subclass of Coroutine (and overriding
+ * {@link #run()}) or by providing a {@link Runnable} to the Coroutine constructor.
+ * <p>
+ * An implementation of a simple Coroutine might look like this:
+ * <hr>
+ * <blockquote>
+ *
+ * <pre>
+ * class Numbers extends Coroutine {
+ * 	public void run() {
+ * 		for (int i = 0; i &lt; 10; i++) {
+ * 			System.out.println(i);
+ * 			yield();
+ * 		}
+ * 	}
+ * }
+ * </pre>
+ *
+ * </blockquote>
+ * <hr>
+ * <p>
+ * A Coroutine is active as soon as it is created, and will run as soon as control is transferred to it:
+ * <blockquote>
+ *
+ * <pre>
+ * new Numbers();
+ * for (int i = 0; i &lt; 10; i++)
+ * 	yield();
+ * </pre>
+ *
+ * </blockquote>
+ * 
+ * @author Lukas Stadler
+ */
+public class Coroutine extends CoroutineBase {
+	private final Runnable target;
+
+	Coroutine next;
+	Coroutine last;
+
+    /**
+     * Allocates a new {@code Coroutine} object.
+     */
+	public Coroutine() {
+		this.target = null;
+		threadSupport.addCoroutine(this, -1);
+	}
+
+    /**
+     * Allocates a new {@code Coroutine} object.
+     * @param target the runnable
+     */
+	public Coroutine(Runnable target) {
+		this.target = target;
+		threadSupport.addCoroutine(this, -1);
+	}
+
+    /**
+     * Allocates a new {@code Coroutine} object.
+     * @param stacksize the size of stack
+     */
+	public Coroutine(long stacksize) {
+		this.target = null;
+		threadSupport.addCoroutine(this, stacksize);
+	}
+
+    /**
+     * Allocates a new {@code Coroutine} object.
+     * @param target runnable
+     * @param stacksize the size of stack
+     */
+	public Coroutine(Runnable target, long stacksize) {
+		this.target = target;
+		threadSupport.addCoroutine(this, stacksize);
+	}
+
+	/**
+     * Creates the initial coroutine for a new thread
+     * @param threadSupport the CoroutineSupport
+     * @param data the value
+     */
+	Coroutine(CoroutineSupport threadSupport, long data) {
+		super(threadSupport, data);
+		this.target = null;
+	}
+
+	/**
+	 * Yields execution to the next coroutine in the current threads coroutine queue.
+	 */
+	public static void yield() {
+		Thread.currentThread().getCoroutineSupport().symmetricYield();
+	}
+
+	/**
+	 * Yields execution to the other coroutine.
+     * @param target Coroutine
+	 */
+	public static void yieldTo(Coroutine target) {
+		Thread.currentThread().getCoroutineSupport().symmetricYieldTo(target);
+	}
+
+	/**
+	 * Coroutine exit.
+	 */
+	public void stop() {
+		Thread.currentThread().getCoroutineSupport().symmetricStopCoroutine(this);
+	}
+
+    /**
+     * the entry to run the coroutine
+     */
+	protected void run() {
+		assert Thread.currentThread() == threadSupport.getThread();
+		if (target != null) {
+			target.run();
+		}
+	}
+}

--- a/src/java.base/share/classes/java/dyn/CoroutineBase.java
+++ b/src/java.base/share/classes/java/dyn/CoroutineBase.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2010, 2012, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package java.dyn;
+/**
+ *  * Abstract of coroutines.
+ */
+public abstract class CoroutineBase {
+	transient long data;
+
+	boolean finished = false;
+
+	transient CoroutineSupport threadSupport;
+
+    /**
+     *  Allocates a new {@code CoroutineBase} object.
+     */
+	CoroutineBase() {
+		Thread thread = Thread.currentThread();
+		assert thread.getCoroutineSupport() != null;
+		this.threadSupport = thread.getCoroutineSupport();
+	}
+
+	/**
+     * Creates the initial coroutine for a new thread
+     * @param threadSupport CoroutineSupport
+     * @param data value
+     */
+	CoroutineBase(CoroutineSupport threadSupport, long data) {
+		this.threadSupport = threadSupport;
+		this.data = data;
+	}
+
+    /**
+     * abstract for the entry of coroutine
+     */
+	protected abstract void run();
+
+	@SuppressWarnings({ "unused" })
+	private final void startInternal() {
+		assert threadSupport.getThread() == Thread.currentThread();
+		try {
+			if (CoroutineSupport.DEBUG) {
+				System.out.println("starting coroutine " + this);
+			}
+			run();
+		} catch (Throwable t) {
+			if (!(t instanceof CoroutineExitException)) {
+				t.printStackTrace();
+			}
+		} finally {
+			finished = true;
+			// use Thread.currentThread().getCoroutineSupport() because we might have been migrated to another thread!
+			Thread.currentThread().getCoroutineSupport().terminateCoroutine();
+		}
+		assert threadSupport.getThread() == Thread.currentThread();
+	}
+
+	/**
+	 * @return true if this coroutine has reached its end. Under normal circumstances this happens when the {@link #run()} method returns.
+     */
+	public final boolean isFinished() {
+		return finished;
+	}
+
+	/**
+	 * @return the thread that this coroutine is associated with
+	 * @throws NullPointerException
+	 *             if the coroutine has terminated
+	 */
+	public Thread getThread() {
+		return threadSupport.getThread();
+	}
+
+    /**
+     * @return the current coroutine in the thread
+     */
+	public static CoroutineBase current() {
+		return Thread.currentThread().getCoroutineSupport().getCurrent();
+	}
+}

--- a/src/java.base/share/classes/java/dyn/CoroutineExitException.java
+++ b/src/java.base/share/classes/java/dyn/CoroutineExitException.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2010, 2012, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package java.dyn;
+
+/**
+ * Implementation of exeception for coroutine exit
+ */
+public class CoroutineExitException extends RuntimeException {
+	private static final long serialVersionUID = -2651365020938997924L;
+
+    /**
+     * Allocates a new {@code CoroutineExitException} object
+     */
+	public CoroutineExitException() {
+	}
+
+    /**
+     * Allocates a new {@code CoroutineExitException} object
+     * @param message String
+     * @param cause Throwable
+     */
+	public CoroutineExitException(String message, Throwable cause) {
+		super(message, cause);
+	}
+
+    /**
+     * Allocates a new {@code CoroutineExitException} object
+     * @param message String
+     */
+	public CoroutineExitException(String message) {
+		super(message);
+	}
+
+    /**
+     * Allocates a new {@code CoroutineExitException} object
+     * @param cause Throwable
+     */
+	public CoroutineExitException(Throwable cause) {
+		super(cause);
+	}
+}

--- a/src/java.base/share/classes/java/dyn/CoroutineSupport.java
+++ b/src/java.base/share/classes/java/dyn/CoroutineSupport.java
@@ -1,0 +1,301 @@
+/*
+ * Copyright (c) 2010, 2012, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package java.dyn;
+
+import jdk.internal.vm.annotation.IntrinsicCandidate;
+import sun.reflect.generics.reflectiveObjects.NotImplementedException;
+
+/**
+ * The implementation of Coroutine support
+ */
+public class CoroutineSupport {
+	// Controls debugging and tracing, for maximum performance the actual if(DEBUG/TRACE) code needs to be commented out
+	static final boolean DEBUG = false;
+	static final boolean TRACE = false;
+
+	static final Object TERMINATED = new Object();
+
+	// The thread that this CoroutineSupport belongs to. There's only one CoroutineSupport per Thread
+	private final Thread thread;
+	// The initial coroutine of the Thread
+	private final Coroutine threadCoroutine;
+
+	// The currently executing, symmetric or asymmetric coroutine
+	CoroutineBase currentCoroutine;
+	// The anchor of the doubly-linked ring of coroutines
+	Coroutine scheduledCoroutines;
+
+	static {
+		registerNatives();
+	}
+
+    /**
+     * Allocates a new {@code CoroutineSupport} object.
+     * @param thread the Thread
+     */
+	public CoroutineSupport(Thread thread) {
+		if (thread.getCoroutineSupport() != null) {
+			throw new IllegalArgumentException("Cannot instantiate CoroutineThreadSupport for existing Thread");
+		}
+		this.thread = thread;
+		threadCoroutine = new Coroutine(this, getThreadCoroutine());
+		threadCoroutine.next = threadCoroutine;
+		threadCoroutine.last = threadCoroutine;
+		currentCoroutine = threadCoroutine;
+		scheduledCoroutines = threadCoroutine;
+	}
+
+    /**
+     * return the threadCoroutine
+     * @return threadCoroutine
+     */
+    public Coroutine threadCoroutine() {
+        return threadCoroutine;
+    }
+
+    /**
+     * Add a coroutine in coroutine list
+     * @param coroutine Coroutine
+     * @param stacksize the size of stack
+     */
+	void addCoroutine(Coroutine coroutine, long stacksize) {
+		assert scheduledCoroutines != null;
+		assert currentCoroutine != null;
+
+		coroutine.data = createCoroutine(coroutine, stacksize);
+		if (DEBUG) {
+			System.out.println("add Coroutine " + coroutine + ", data" + coroutine.data);
+		}
+
+		// add the coroutine into the doubly linked ring
+		coroutine.next = scheduledCoroutines.next;
+		coroutine.last = scheduledCoroutines;
+		scheduledCoroutines.next = coroutine;
+		coroutine.next.last = coroutine;
+	}
+
+	Thread getThread() {
+		return thread;
+	}
+
+    /**
+     * drain coroutine
+     */
+	public void drain() {
+		if (Thread.currentThread() != thread) {
+			throw new IllegalArgumentException("Cannot drain another threads CoroutineThreadSupport");
+		}
+
+		if (DEBUG) {
+			System.out.println("draining");
+		}
+		try {
+			// drain all scheduled coroutines
+			while (scheduledCoroutines.next != scheduledCoroutines) {
+				symmetricExitInternal(scheduledCoroutines.next);
+			}
+
+			CoroutineBase coro;
+			while ((coro = cleanupCoroutine()) != null) {
+				System.out.println(coro);
+				throw new NotImplementedException();
+			}
+		} catch (Throwable t) {
+			t.printStackTrace();
+		}
+	}
+
+    /**
+     * switch to the next coroutine
+     */
+	void symmetricYield() {
+		if (scheduledCoroutines != currentCoroutine) {
+			throw new IllegalThreadStateException("Cannot call yield from within an asymmetric coroutine");
+		}
+		assert currentCoroutine instanceof Coroutine;
+
+		if (TRACE) {
+			System.out.println("locking for symmetric yield...");
+		}
+
+		Coroutine next = scheduledCoroutines.next;
+		if (next == scheduledCoroutines) {
+			return;
+		}
+
+		if (TRACE) {
+			System.out.println("symmetric yield to " + next);
+		}
+
+		final Coroutine current = scheduledCoroutines;
+		scheduledCoroutines = next;
+		currentCoroutine = next;
+
+		switchTo(current, next);
+	}
+
+    /**
+     * switch to the the coroutine
+     * @param target Coroutine
+     */
+	public void symmetricYieldTo(Coroutine target) {
+		if (scheduledCoroutines != currentCoroutine) {
+			throw new IllegalThreadStateException("Cannot call yield from within an asymmetric coroutine");
+		}
+		assert currentCoroutine instanceof Coroutine;
+
+		moveCoroutine(scheduledCoroutines, target);
+
+		final Coroutine current = scheduledCoroutines;
+		scheduledCoroutines = target;
+		currentCoroutine = target;
+
+		switchTo(current, target);
+	}
+
+    /**
+     * change the coroutine list
+     * @param a coroutine
+     * @param position coroutine
+     */
+	private void moveCoroutine(Coroutine a, Coroutine position) {
+		// remove a from the ring
+		a.last.next = a.next;
+		a.next.last = a.last;
+
+		// ... and insert at the new position
+		a.next = position.next;
+		a.last = position;
+		a.next.last = a;
+		position.next = a;
+	}
+
+    /**
+     * switch to other coroutine, and stop the current.
+     * @param target Coroutine
+     */
+	public void symmetricStopCoroutine(Coroutine target) {
+		if (scheduledCoroutines != currentCoroutine) {
+			throw new IllegalThreadStateException("Cannot call yield from within an asymmetric coroutine");
+		}
+		assert currentCoroutine instanceof Coroutine;
+
+		moveCoroutine(scheduledCoroutines, target);
+
+		final Coroutine current = scheduledCoroutines;
+		scheduledCoroutines = target;
+		currentCoroutine = target;
+
+		switchToAndExit(current, target);
+	}
+
+    /**
+     * stop the coroutine
+     * @param coroutine Coroutine
+     */
+	void symmetricExitInternal(Coroutine coroutine) {
+		if (scheduledCoroutines != currentCoroutine) {
+			throw new IllegalThreadStateException("Cannot call exitNext from within an unscheduled coroutine");
+		}
+		assert currentCoroutine instanceof Coroutine;
+		assert currentCoroutine != coroutine;
+
+		// remove the coroutine from the ring
+		coroutine.last.next = coroutine.next;
+		coroutine.next.last = coroutine.last;
+
+		if (!isDisposable(coroutine.data)) {
+			// and insert it before the current coroutine
+			coroutine.last = scheduledCoroutines.last;
+			coroutine.next = scheduledCoroutines;
+			coroutine.last.next = coroutine;
+			scheduledCoroutines.last = coroutine;
+
+			final Coroutine current = scheduledCoroutines;
+			scheduledCoroutines = coroutine;
+			currentCoroutine = coroutine;
+			switchToAndExit(current, coroutine);
+		}
+	}
+
+    /**
+     * terminate the current coroutine
+     */
+	void terminateCoroutine() {
+		assert currentCoroutine == scheduledCoroutines;
+		assert currentCoroutine != threadCoroutine : "cannot exit thread coroutine";
+		assert scheduledCoroutines != scheduledCoroutines.next : "last coroutine shouldn't call coroutineexit";
+
+		Coroutine old = scheduledCoroutines;
+		Coroutine forward = old.next;
+		currentCoroutine = forward;
+		scheduledCoroutines = forward;
+		old.last.next = old.next;
+		old.next.last = old.last;
+
+		if (DEBUG) {
+			System.out.println("to be terminated: " + old);
+		}
+		switchToAndTerminate(old, forward);
+	}
+
+    /**
+     * check whether the coroutine is the current
+     * @param coroutine CoroutineBase
+     * @return true if it is current
+     */
+	public boolean isCurrent(CoroutineBase coroutine) {
+		return coroutine == currentCoroutine;
+	}
+
+    /**
+     * get the current coroutine
+     * @return the current coroutine
+     */
+	public CoroutineBase getCurrent() {
+		return currentCoroutine;
+	}
+
+	private static native void registerNatives();
+
+	private static native long getThreadCoroutine();
+
+	private static native long createCoroutine(CoroutineBase coroutine, long stacksize);
+
+    @IntrinsicCandidate
+	private static native void switchTo(CoroutineBase current, CoroutineBase target);
+
+    @IntrinsicCandidate
+	private static native void switchToAndTerminate(CoroutineBase current, CoroutineBase target);
+
+    @IntrinsicCandidate
+	private static native void switchToAndExit(CoroutineBase current, CoroutineBase target);
+
+	private static native boolean isDisposable(long coroutine);
+
+	private static native CoroutineBase cleanupCoroutine();
+
+}

--- a/src/java.base/share/classes/java/lang/Thread.java
+++ b/src/java.base/share/classes/java/lang/Thread.java
@@ -25,6 +25,7 @@
 
 package java.lang;
 
+import java.dyn.CoroutineSupport;
 import java.lang.ref.Reference;
 import java.lang.ref.ReferenceQueue;
 import java.lang.ref.WeakReference;
@@ -251,6 +252,27 @@ public class Thread implements Runnable {
      * The maximum priority that a thread can have.
      */
     public static final int MAX_PRIORITY = 10;
+
+    /**
+     * The coroutine support of the thread
+     */
+    private CoroutineSupport coroutineSupport;
+
+    /**
+     * @return the coroutine support of the thread
+     */
+    public CoroutineSupport getCoroutineSupport() {
+        return coroutineSupport;
+    }
+
+    /**
+     * initialize the coroutine support of the thread
+     */
+    private void initializeCoroutineSupport() {
+        if (jdk.internal.misc.VM.isEnableCoroutine()) {
+            coroutineSupport = new CoroutineSupport(this);
+        }
+    }
 
     /**
      * Returns a reference to the currently executing thread object.
@@ -841,6 +863,9 @@ public class Thread implements Runnable {
     private void exit() {
         if (threadLocals != null && TerminatingThreadLocal.REGISTRY.isPresent()) {
             TerminatingThreadLocal.threadTerminated();
+        }
+        if (jdk.internal.misc.VM.isEnableCoroutine() && (coroutineSupport != null)) {
+            coroutineSupport.drain();
         }
         if (group != null) {
             group.threadTerminated(this);

--- a/src/java.base/share/classes/jdk/internal/misc/VM.java
+++ b/src/java.base/share/classes/jdk/internal/misc/VM.java
@@ -118,6 +118,12 @@ public class VM {
         return initLevel == SYSTEM_SHUTDOWN;
     }
 
+    private static boolean enableCoroutine;
+
+    public static boolean isEnableCoroutine() {
+        return enableCoroutine;
+    }
+
     // A user-settable upper limit on the maximum amount of allocatable direct
     // buffer memory.  This value may be changed during VM initialization if
     // "java" is launched with "-XX:MaxDirectMemorySize=<size>".
@@ -239,6 +245,10 @@ public class VM {
         if (savedProps == null) {
             savedProps = props;
         }
+
+        //Set the enableCoroutine flag, This value is controlled
+        //by the vm option -XX:+EnableCoroutine
+        enableCoroutine = Boolean.valueOf(props.remove("com.alibaba.coroutine.enableCoroutine"));
 
         // Set the maximum amount of direct memory.  This value is controlled
         // by the vm option -XX:MaxDirectMemorySize=<size>.

--- a/src/java.base/share/classes/module-info.java
+++ b/src/java.base/share/classes/module-info.java
@@ -76,6 +76,7 @@
  */
 module java.base {
 
+    exports java.dyn;
     exports java.io;
     exports java.lang;
     exports java.lang.annotation;

--- a/test/hotspot/jtreg/runtime/coroutine/AvoidDeoptCoroutineMethodTest.java
+++ b/test/hotspot/jtreg/runtime/coroutine/AvoidDeoptCoroutineMethodTest.java
@@ -1,0 +1,34 @@
+/*
+ * @test TestAvoidDeoptCoroutineMethod
+ * @library /test/lib
+ * @build sun.hotspot.WhiteBox
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller sun.hotspot.WhiteBox
+ * @build AvoidDeoptCoroutineMethodTest
+ * @run main/othervm -XX:+EnableCoroutine -Xmx10m -Xms10m -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI AvoidDeoptCoroutineMethodTest
+ * @summary test avoid coroutine intrinsic method to be deoptimized
+ */
+
+import sun.hotspot.WhiteBox;
+import java.dyn.Coroutine;
+import java.io.*;
+
+public class AvoidDeoptCoroutineMethodTest {
+    public static void main(String[] args) throws Exception {
+        WhiteBox whiteBox = WhiteBox.getWhiteBox();
+        Coroutine threadCoro = Thread.currentThread().getCoroutineSupport().threadCoroutine();
+        runSomeCoroutines(threadCoro);
+        // deoptimize all
+        whiteBox.deoptimizeAll();
+        // if intrinsic methods of coroutine have been deoptimized, it will crash here
+        runSomeCoroutines(threadCoro);
+    }
+
+    private static void runSomeCoroutines(Coroutine threadCoro) throws Exception {
+        for (int i = 0; i < 10000; i++) {
+            new Coroutine(() -> {});
+            Coroutine.yieldTo(threadCoro); // switch to new created coroutine and let it die
+        }
+        System.out.println("end of run");
+    }
+}
+

--- a/test/hotspot/jtreg/runtime/coroutine/MemLeakTest.java
+++ b/test/hotspot/jtreg/runtime/coroutine/MemLeakTest.java
@@ -1,0 +1,92 @@
+/*
+ * @test
+ * @summary test of memory leak while creating and destroying coroutine/thread
+ * @run main/othervm -XX:+EnableCoroutine  -Xmx10m  -Xms10m MemLeakTest
+ */
+
+import java.dyn.Coroutine;
+import java.io.*;
+
+public class MemLeakTest {
+    private final static Runnable r = () -> {};
+
+    public static void main(String[] args) throws Exception {
+        testThreadCoroutineLeak();
+        testUserCreatedCoroutineLeak();
+    }
+
+
+    /**
+     * Before fix:  35128kB -> 40124kB
+     * After fix :  28368kB -> 28424kB
+     */
+    private static void testThreadCoroutineLeak() throws Exception {
+        // occupy rss
+        for (int i = 0; i < 20000; i++) {
+            Thread t = new Thread(r);
+            t.start();
+            t.join();
+        }
+
+        int rss0 = getRssInKb();
+        System.out.println(rss0);
+
+        for (int i = 0; i < 20000; i++) {
+            Thread t = new Thread(r);
+            t.start();
+            t.join();
+        }
+
+        int rss1 = getRssInKb();
+        System.out.println(rss1);
+
+        if (rss1 - rss0 > 1024) { // 1M
+            throw new Error("thread coroutine mem leak");
+        }
+    }
+
+    /**
+     * Before fix:  152892kB -> 280904kB
+     * After fix :  25436kB -> 25572kB
+     */
+    private static void testUserCreatedCoroutineLeak() throws Exception {
+        // occupy rss
+        for (int i = 0; i < 200000; i++) {
+            new Coroutine(r);
+            Coroutine.yield(); // switch to new created coroutine and let it die
+        }
+
+        int rss0 = getRssInKb();
+        System.out.println(rss0);
+
+        for (int i = 0; i < 200000; i++) {
+            new Coroutine(r);
+            Coroutine.yield();
+        }
+
+        int rss1 = getRssInKb();
+        System.out.println(rss1);
+        if (rss1 - rss0 > 1024) { // 1M
+            throw new Error("user created coroutine mem leak");
+        }
+    }
+
+
+    private static int getRssInKb() throws IOException {
+        try (BufferedReader br = new BufferedReader(new FileReader("/proc/self/status"))) {
+            int rss = -1;
+            String line;
+            while ((line = br.readLine()) != null) {
+                //i.e.  VmRSS:       360 kB
+                if (line.trim().startsWith("VmRSS:")) {
+                    int numEnd = line.length() - 3;
+                    int numBegin = line.lastIndexOf(" ", numEnd - 1) + 1;
+                    rss = Integer.parseInt(line.substring(numBegin, numEnd));
+                    break;
+                }
+            }
+            return rss;
+        }
+    }
+}
+

--- a/test/jdk/java/dyn/CoroutineTest.java
+++ b/test/jdk/java/dyn/CoroutineTest.java
@@ -1,0 +1,234 @@
+/*
+ * Copyright (c) 2010, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/* @test
+ * @summary unit tests for coroutines
+ * @run junit/othervm -XX:+EnableCoroutine test.java.dyn.CoroutineTest
+ */
+
+package test.java.dyn;
+
+import java.dyn.Coroutine;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+
+import static org.junit.Assert.*;
+
+import org.junit.Before;
+import org.junit.Test;
+
+public class CoroutineTest {
+	private StringBuilder seq;
+
+	@Before
+	public void before() {
+		seq = new StringBuilder();
+		seq.append("a");
+	}
+
+	@Test
+	public void symSequence() {
+		Coroutine coro = new Coroutine() {
+			protected void run() {
+				seq.append("c");
+				for (int i = 0; i < 3; i++) {
+					yield();
+					seq.append("e");
+				}
+			}
+		};
+		seq.append("b");
+		assertFalse(coro.isFinished());
+		Coroutine.yield();
+		for (int i = 0; i < 3; i++) {
+			seq.append("d");
+			assertFalse(coro.isFinished());
+			Coroutine.yield();
+		}
+		seq.append("f");
+		assertTrue(coro.isFinished());
+		Coroutine.yield();
+		seq.append("g");
+		assertEquals("abcdededefg", seq.toString());
+	}
+
+	@Test
+	public void symMultiSequence() {
+		for (int i = 0; i < 10; i++)
+			new Coroutine() {
+				protected void run() {
+					seq.append("c");
+					yield();
+					seq.append("e");
+				}
+			};
+		seq.append("b");
+		Coroutine.yield();
+		seq.append("d");
+		Coroutine.yield();
+		seq.append("f");
+		Coroutine.yield();
+		seq.append("g");
+		assertEquals("abccccccccccdeeeeeeeeeefg", seq.toString());
+	}
+
+	@Test
+	public void gcTest1() {
+		new Coroutine() {
+			protected void run() {
+				seq.append("c");
+				Integer v1 = 1;
+				Integer v2 = 14555668;
+				yield();
+				seq.append("e");
+				seq.append("(" + v1 + "," + v2 + ")");
+			}
+		};
+		seq.append("b");
+		System.gc();
+		Coroutine.yield();
+		System.gc();
+		seq.append("d");
+		Coroutine.yield();
+		seq.append("f");
+		Coroutine.yield();
+		seq.append("g");
+		assertEquals("abcde(1,14555668)fg", seq.toString());
+	}
+
+	@Test
+	public void exceptionTest1() {
+		Coroutine coro = new Coroutine() {
+			protected void run() {
+				seq.append("c");
+				long temp = System.nanoTime();
+				if (temp != 0)
+					throw new RuntimeException();
+				yield();
+				seq.append("e");
+			}
+		};
+		seq.append("b");
+		assertFalse(coro.isFinished());
+		Coroutine.yield();
+		seq.append("d");
+		Coroutine.yield();
+		seq.append("f");
+		assertEquals("abcdf", seq.toString());
+	}
+
+	@Test
+	public void largeStackframeTest() {
+		new Coroutine() {
+			protected void run() {
+				seq.append("c");
+				Integer v0 = 10000;
+				Integer v1 = 10001;
+				Integer v2 = 10002;
+				Integer v3 = 10003;
+				Integer v4 = 10004;
+				Integer v5 = 10005;
+				Integer v6 = 10006;
+				Integer v7 = 10007;
+				Integer v8 = 10008;
+				Integer v9 = 10009;
+				Integer v10 = 10010;
+				Integer v11 = 10011;
+				Integer v12 = 10012;
+				Integer v13 = 10013;
+				Integer v14 = 10014;
+				Integer v15 = 10015;
+				Integer v16 = 10016;
+				Integer v17 = 10017;
+				Integer v18 = 10018;
+				Integer v19 = 10019;
+				yield();
+				int sum = v0 + v1 + v2 + v3 + v4 + v5 + v6 + v7 + v8 + v9 + v10 + v11 + v12 + v13 + v14 + v15 + v16 + v17 + v18 + v19;
+				seq.append("e" + sum);
+			}
+		};
+		seq.append("b");
+		System.gc();
+		Coroutine.yield();
+		System.gc();
+		seq.append("d");
+		Coroutine.yield();
+		seq.append("f");
+		assertEquals("abcde200190f", seq.toString());
+	}
+
+	@Test
+	public void shaTest() {
+		Coroutine coro = new Coroutine(65536) {
+			protected void run() {
+				try {
+					MessageDigest digest = MessageDigest.getInstance("SHA");
+					digest.update("TestMessage".getBytes());
+					seq.append("b");
+					yield();
+					seq.append(digest.digest()[0]);
+				} catch (NoSuchAlgorithmException e) {
+					e.printStackTrace();
+				}
+			}
+		};
+		Coroutine.yield();
+		seq.append("c");
+		assertFalse(coro.isFinished());
+		Coroutine.yield();
+		assertTrue(coro.isFinished());
+		assertEquals("abc72", seq.toString());
+	}
+
+	public void stackoverflowTest() {
+		for (int i = 0; i < 10; i++) {
+			new Coroutine(65536) {
+				int i = 0;
+
+				protected void run() {
+					System.out.println("start");
+					try {
+						iter();
+					} catch (StackOverflowError e) {
+						System.out.println("i: " + i);
+					}
+					System.out.println("asdf");
+				}
+
+				private void iter() {
+					System.out.print(".");
+					i++;
+					iter();
+				}
+			};
+		}
+		Coroutine.yield();
+	}
+
+  @Test
+	public void destroyNonInitedTest() {
+    new Coroutine();
+  }
+}

--- a/test/jdk/java/dyn/CoroutineTest.java
+++ b/test/jdk/java/dyn/CoroutineTest.java
@@ -54,7 +54,7 @@ public class CoroutineTest {
 			protected void run() {
 				seq.append("c");
 				for (int i = 0; i < 3; i++) {
-					yield();
+					Thread.yield();
 					seq.append("e");
 				}
 			}
@@ -80,7 +80,7 @@ public class CoroutineTest {
 			new Coroutine() {
 				protected void run() {
 					seq.append("c");
-					yield();
+					Thread.yield();
 					seq.append("e");
 				}
 			};
@@ -101,7 +101,7 @@ public class CoroutineTest {
 				seq.append("c");
 				Integer v1 = 1;
 				Integer v2 = 14555668;
-				yield();
+				Thread.yield();
 				seq.append("e");
 				seq.append("(" + v1 + "," + v2 + ")");
 			}
@@ -126,7 +126,7 @@ public class CoroutineTest {
 				long temp = System.nanoTime();
 				if (temp != 0)
 					throw new RuntimeException();
-				yield();
+				Thread.yield();
 				seq.append("e");
 			}
 		};
@@ -164,7 +164,7 @@ public class CoroutineTest {
 				Integer v17 = 10017;
 				Integer v18 = 10018;
 				Integer v19 = 10019;
-				yield();
+				Thread.yield();
 				int sum = v0 + v1 + v2 + v3 + v4 + v5 + v6 + v7 + v8 + v9 + v10 + v11 + v12 + v13 + v14 + v15 + v16 + v17 + v18 + v19;
 				seq.append("e" + sum);
 			}
@@ -187,7 +187,7 @@ public class CoroutineTest {
 					MessageDigest digest = MessageDigest.getInstance("SHA");
 					digest.update("TestMessage".getBytes());
 					seq.append("b");
-					yield();
+					Thread.yield();
 					seq.append(digest.digest()[0]);
 				} catch (NoSuchAlgorithmException e) {
 					e.printStackTrace();


### PR DESCRIPTION
[Wisp] Port JKU coroutine support to JDK17.

Summary:
    Following features are included in this patch
        - From http://hg.openjdk.java.net/mlvm/mlvm/hotspot/file/4cd7d914b0e3/coro-simple.patch
        - Resolve trivial conflicts in: systemDictionary.hpp, thread.cpp, debug.hpp
        - Add an option "EnableCoroutine"
        - Fix crash while destroying a non-inited coroutine
        - Fix native heap memory leak
        - remove AsymCoroutine for JKU coroutine
        - avoid deoptimizing intrinsic methods of coroutine klass

Test Plan:
        test/hotspot/jtreg/runtime/coroutine/MemLeakTest.java
        test/hotspot/jtreg/runtime/coroutine/AvoidDeoptCoroutineMethodTest.java

Reviewed-by: yulei

Issue:
    https://github.com/dragonwell-project/dragonwell17/issues/71