### PR TITLE
[EagerAppCDS] add EagerAppCDS

### DIFF
--- a/make/data/hotspot-symbols/symbols-unix
+++ b/make/data/hotspot-symbols/symbols-unix
@@ -49,6 +49,7 @@ JVM_ConstantPoolGetUTF8At
 JVM_CurrentThread
 JVM_CurrentTimeMillis
 JVM_DefineClass
+JVM_DefineClassFromCDS
 JVM_DefineClassWithSource
 JVM_DesiredAssertionStatus
 JVM_DumpAllStacks

--- a/src/hotspot/share/cds/classListParser.hpp
+++ b/src/hotspot/share/cds/classListParser.hpp
@@ -100,11 +100,17 @@ class ClassListParser : public StackObj {
   int                 _super;
   GrowableArray<int>* _interfaces;
   bool                _interfaces_specified;
+  int                 _defining_loader_hash;
+  int                 _initiating_loader_hash;
   const char*         _source;
   bool                _lambda_form_line;
+  uint64_t            _fingerprint;
+  int                 _dependence_not_loaded;
 
   bool parse_int_option(const char* option_name, int* value);
   bool parse_uint_option(const char* option_name, int* value);
+  bool parse_hex_option(const char* option_name, int* value);
+  bool parse_uint64_option(const char* option_name, uint64_t* value);
   InstanceKlass* load_class_from_source(Symbol* class_name, TRAPS);
   ID2KlassTable* table() {
     return &_id2klass_table;
@@ -160,10 +166,19 @@ public:
     assert(is_super_specified(), "do not query unspecified super");
     return _super;
   }
-  void check_already_loaded(const char* which, int id) {
+
+  bool check_already_loaded(const char* which, int id) {
     if (_id2klass_table.lookup(id) == NULL) {
-      error("%s id %d is not yet loaded", which, id);
+      if (EagerAppCDS) {
+        // In EagerAppCDS flow, if the supper class is not loaded, we don't error out.
+        _dependence_not_loaded = 1;
+        tty->print_cr("Preload Warning: %s id %d is not yet loaded", which, id);
+      } else {
+        error("%s id %d is not yet loaded", which, id);
+      }
+      return false;
     }
+    return true;
   }
 
   const char* current_class_name() {
@@ -178,6 +193,7 @@ public:
   // (in this->load_current_class()).
   InstanceKlass* lookup_super_for_current_class(Symbol* super_name);
   InstanceKlass* lookup_interface_for_current_class(Symbol* interface_name);
+  bool dependence_not_loaded() const { return _dependence_not_loaded == 1; }
 
   static void populate_cds_indy_info(const constantPoolHandle &pool, int cp_index, CDSIndyInfo* cii, TRAPS);
 };

--- a/src/hotspot/share/classfile/classFileParser.hpp
+++ b/src/hotspot/share/classfile/classFileParser.hpp
@@ -209,6 +209,7 @@ class ClassFileParser {
   void fill_instance_klass(InstanceKlass* ik, bool cf_changed_in_CFLH,
                            const ClassInstanceInfo& cl_inst_info, TRAPS);
 
+  void set_class_source(InstanceKlass* ik, TRAPS);
   void set_klass(InstanceKlass* instance);
 
   void set_class_bad_constant_seen(short bad_constant);
@@ -525,6 +526,10 @@ class ClassFileParser {
                                TRAPS);
 
   void update_class_name(Symbol* new_name);
+
+#if INCLUDE_CDS
+  void log_loaded_klass(InstanceKlass* k, const ClassFileStream* stream, TRAPS);
+#endif
 
  public:
   ClassFileParser(ClassFileStream* stream,

--- a/src/hotspot/share/classfile/classFileStream.cpp
+++ b/src/hotspot/share/classfile/classFileStream.cpp
@@ -75,3 +75,12 @@ const ClassFileStream* ClassFileStream::clone() const {
                              need_verify(),
                              from_boot_loader_modules_image());
 }
+
+uint64_t ClassFileStream::compute_fingerprint() const {
+  int classfile_size = length();
+  int classfile_crc = ClassLoader::crc32(0, (const char*)buffer(), length());
+  uint64_t fingerprint = (uint64_t(classfile_size) << 32) | uint64_t(uint32_t(classfile_crc));
+  assert(fingerprint != 0, "must not be zero");
+
+  return fingerprint;
+}

--- a/src/hotspot/share/classfile/classLoader.hpp
+++ b/src/hotspot/share/classfile/classLoader.hpp
@@ -384,6 +384,9 @@ class ClassLoader: AllStatic {
   static jlong class_link_count();
   static jlong class_link_time_ms();
 
+  // indicates if class path already contains a entry (exact match by name)
+  static bool contains_append_entry(const char* name);
+
   // adds a class path to the boot append entries
   static void add_to_boot_append_entries(ClassPathEntry* new_entry);
 

--- a/src/hotspot/share/classfile/classLoaderExt.hpp
+++ b/src/hotspot/share/classfile/classLoaderExt.hpp
@@ -108,7 +108,8 @@ public:
   }
 
   static void record_result(const s2 classpath_index, InstanceKlass* result);
-  static InstanceKlass* load_class(Symbol* h_name, const char* path, TRAPS);
+  static InstanceKlass* load_class(Symbol* h_name, const char* path, int defining_loader_hash,
+                                  int initiating_loader_hash, uint64_t fingerprint, TRAPS);
   static void set_has_app_classes() {
     _has_app_classes = true;
   }

--- a/src/hotspot/share/classfile/javaClasses.cpp
+++ b/src/hotspot/share/classfile/javaClasses.cpp
@@ -4362,6 +4362,7 @@ int  java_lang_ClassLoader::_name_offset;
 int  java_lang_ClassLoader::_nameAndId_offset;
 int  java_lang_ClassLoader::_unnamedModule_offset;
 int  java_lang_ClassLoader::_parent_offset;
+int  java_lang_ClassLoader::_signature_offset = -1;
 
 ClassLoaderData* java_lang_ClassLoader::loader_data_acquire(oop loader) {
   assert(loader != NULL, "loader must not be NULL");
@@ -4386,7 +4387,8 @@ void java_lang_ClassLoader::release_set_loader_data(oop loader, ClassLoaderData*
   macro(_name_offset,            k1, vmSymbols::name_name(), string_signature, false); \
   macro(_nameAndId_offset,       k1, "nameAndId",            string_signature, false); \
   macro(_unnamedModule_offset,   k1, "unnamedModule",        module_signature, false); \
-  macro(_parent_offset,          k1, "parent",               classloader_signature, false)
+  macro(_parent_offset,          k1, "parent",               classloader_signature, false); \
+  macro(_signature_offset,       k1, "signature",            int_signature, false)
 
 void java_lang_ClassLoader::compute_offsets() {
   InstanceKlass* k1 = vmClasses::ClassLoader_klass();
@@ -4491,6 +4493,11 @@ oop java_lang_ClassLoader::non_reflection_class_loader(oop loader) {
 oop java_lang_ClassLoader::unnamedModule(oop loader) {
   assert(is_instance(loader), "loader must be oop");
   return loader->obj_field(_unnamedModule_offset);
+}
+
+int java_lang_ClassLoader::signature(oop loader) {
+  assert(is_instance(loader), "loader must be oop");
+  return loader->int_field(_signature_offset);
 }
 
 // Support for java_lang_System

--- a/src/hotspot/share/classfile/javaClasses.hpp
+++ b/src/hotspot/share/classfile/javaClasses.hpp
@@ -1352,6 +1352,7 @@ class java_lang_ClassLoader : AllStatic {
   static int _name_offset;
   static int _nameAndId_offset;
   static int _unnamedModule_offset;
+  static int _signature_offset;
 
   static void compute_offsets();
 
@@ -1365,6 +1366,7 @@ class java_lang_ClassLoader : AllStatic {
   static oop parent(oop loader);
   static oop name(oop loader);
   static oop nameAndId(oop loader);
+  static int signature(oop loader);
   static bool isAncestor(oop loader, oop cl);
 
   // Support for parallelCapable field

--- a/src/hotspot/share/classfile/systemDictionary.hpp
+++ b/src/hotspot/share/classfile/systemDictionary.hpp
@@ -336,7 +336,7 @@ private:
                                                 Handle lockObject,
                                                 bool* throw_circularity_error);
 
-  static void define_instance_class(InstanceKlass* k, Handle class_loader, TRAPS);
+
   static InstanceKlass* find_or_define_helper(Symbol* class_name,
                                               Handle class_loader,
                                               InstanceKlass* k, TRAPS);
@@ -359,8 +359,15 @@ private:
                                                Handle protection_domain, TRAPS);
   // Second part of load_shared_class
   static void load_shared_class_misc(InstanceKlass* ik, ClassLoaderData* loader_data) NOT_CDS_RETURN;
+public:
+#if INCLUDE_CDS
+  static void dump_class_and_loader_relationship(InstanceKlass* k, ClassLoaderData* initiating_loader_data, TRAPS);
+  static bool should_not_dump_class(InstanceKlass* k);
+#endif
+  static bool is_parallelCapable(Handle class_loader);
 protected:
-  // Used by SystemDictionaryShared
+  // Used by SystemDictionaryShare
+  static void define_instance_class(InstanceKlass* k, Handle class_loader, TRAPS);
 
   static bool add_loader_constraint(Symbol* name, Klass* klass_being_linked,  Handle loader1,
                                     Handle loader2);
@@ -413,9 +420,11 @@ protected:
                                 InstanceKlass* k, Handle loader);
 
 public:
+  static bool invalid_class_name_for_EagerAppCDS(const char* name);
+
   static TableStatistics placeholders_statistics();
   static TableStatistics loader_constraints_statistics();
   static TableStatistics protection_domain_cache_statistics();
 };
-
+#define DOUBLE_DOLLAR_STR "$$"
 #endif // SHARE_CLASSFILE_SYSTEMDICTIONARY_HPP

--- a/src/hotspot/share/classfile/systemDictionaryShared.hpp
+++ b/src/hotspot/share/classfile/systemDictionaryShared.hpp
@@ -102,6 +102,7 @@
 
 ===============================================================================*/
 #define UNREGISTERED_INDEX -9999
+#define NOT_FOUND_CLASS "not.found.class"
 
 class BootstrapInfo;
 class ClassFileStream;
@@ -201,6 +202,7 @@ private:
                                              ModuleEntry* mod, TRAPS);
 
   static void atomic_set_array_index(OopHandle array, int index, oop o);
+  static bool check_class_not_found(const Symbol *class_name, int hash_value, TRAPS);
 
   static oop shared_protection_domain(int index);
   static void atomic_set_shared_protection_domain(int index, oop pd) {
@@ -248,6 +250,10 @@ public:
   static Handle init_security_info(Handle class_loader, InstanceKlass* ik, PackageEntry* pkg_entry, TRAPS);
   static InstanceKlass* find_builtin_class(Symbol* class_name);
 
+
+  // static const RunTimeSharedClassInfo* find_record_for_unregistered_loader(const Symbol* name,
+  //                                                                          int clsfile_size,
+  //                                                                          int clsfile_crc32);
   static const RunTimeSharedClassInfo* find_record(RunTimeSharedDictionary* static_dict,
                                                    RunTimeSharedDictionary* dynamic_dict,
                                                    Symbol* name);
@@ -277,13 +283,24 @@ public:
   }
 
   static void update_shared_entry(InstanceKlass* klass, int id);
-  static void set_shared_class_misc_info(InstanceKlass* k, ClassFileStream* cfs);
+  static void set_shared_class_misc_info(InstanceKlass* k, ClassFileStream* cfs, int defining_loader_hash, int initiating_loader_hash);
 
+  static void log_not_found_klass(Symbol* name, Handle class_loader, TRAPS);
   static InstanceKlass* lookup_from_stream(Symbol* class_name,
                                            Handle class_loader,
                                            Handle protection_domain,
                                            const ClassFileStream* st,
                                            TRAPS);
+  static InstanceKlass* load_class_from_cds(const Symbol* class_name, Handle class_loader, InstanceKlass* ik, int hash, TRAPS);
+
+  static InstanceKlass* lookup_shared(Symbol* class_name, Handle class_loader,
+                                      bool& not_found, TRAPS);
+
+  static InstanceKlass* define_class_from_cds(InstanceKlass *ik,
+                                              Handle class_loader,
+                                              Handle protection_domain,
+                                              TRAPS);
+
   // "verification_constraints" are a set of checks performed by
   // VerificationType::is_reference_assignable_from when verifying a shared class during
   // dump time.

--- a/src/hotspot/share/classfile/vmSymbols.hpp
+++ b/src/hotspot/share/classfile/vmSymbols.hpp
@@ -393,6 +393,8 @@
   template(run_finalization_name,                     "runFinalization")                          \
   template(dispatchUncaughtException_name,            "dispatchUncaughtException")                \
   template(loadClass_name,                            "loadClass")                                \
+  template(loadClassFromCDS_name,                     "loadClassFromCDS")                         \
+  template(loadClassFromCDS_signature,                "(Ljava/lang/String;Ljava/lang/String;JI)Ljava/lang/Class;") \
   template(get_name,                                  "get")                                      \
   template(refersTo0_name,                            "refersTo0")                                \
   template(put_name,                                  "put")                                      \
@@ -708,6 +710,10 @@
   template(toFileURL_signature,                             "(Ljava/lang/String;)Ljava/net/URL;")                 \
   template(url_void_signature,                              "(Ljava/net/URL;)V")                                  \
                                                                                                                   \
+  /* CDS support */                                                                                               \
+  template(com_alibaba_cds_NotFoundClassSet,           "com/alibaba/cds/NotFoundClassSet")                        \
+  template(isNotFound_name,                            "isNotFound")                                              \
+  template(isNotFound_signature,                       "(Ljava/lang/String;I)Z")                                  \
   /*end*/
 
 // enum for figuring positions and size of Symbol::_vm_symbols[]

--- a/src/hotspot/share/include/jvm.h
+++ b/src/hotspot/share/include/jvm.h
@@ -1130,6 +1130,8 @@ typedef struct JDK1_1InitArgs {
 } JDK1_1InitArgs;
 
 
+JNIEXPORT jclass JNICALL
+JVM_DefineClassFromCDS(JNIEnv *env, jclass clz, jobject loader, jobject pd, jlong iklass);
 #ifdef __cplusplus
 } /* extern "C" */
 

--- a/src/hotspot/share/logging/logTag.hpp
+++ b/src/hotspot/share/logging/logTag.hpp
@@ -68,6 +68,7 @@
   LOG_TAG(director) \
   LOG_TAG(dump) \
   LOG_TAG(dynamic) \
+  LOG_TAG(eagerappcds) \
   LOG_TAG(ergo) \
   LOG_TAG(event) \
   LOG_TAG(exceptions) \

--- a/src/hotspot/share/oops/instanceKlass.cpp
+++ b/src/hotspot/share/oops/instanceKlass.cpp
@@ -490,6 +490,7 @@ InstanceKlass::InstanceKlass(const ClassFileParser& parser, unsigned kind, Klass
   _nest_host(NULL),
   _permitted_subclasses(NULL),
   _record_components(NULL),
+  _source_file_path(NULL),
   _static_field_size(parser.static_field_size()),
   _nonstatic_oop_map_size(nonstatic_oop_map_size(parser.total_oop_map_count())),
   _itable_len(parser.itable_size()),
@@ -2424,6 +2425,10 @@ void InstanceKlass::metaspace_pointers_do(MetaspaceClosure* it) {
   // _fields might be written into by Rewriter::scan_method() -> fd.set_has_initialized_final_update()
   it->push(&_fields, MetaspaceClosure::_writable);
 
+  if (EagerAppCDS) {
+    it->push(&_source_file_path);
+  }
+
   if (itable_length() > 0) {
     itableOffsetEntry* ioe = (itableOffsetEntry*)start_of_itable();
     int method_table_offset_in_words = ioe->offset()/wordSize;
@@ -4217,7 +4222,7 @@ void InstanceKlass::log_to_classlist() const {
        DumpLoadedClassList = NULL;
        return;
     }
-    if (is_shareable()) {
+    if (is_shareable() && !EagerAppCDS) {
       ClassListWriter w;
       w.stream()->print_cr("%s", name()->as_C_string());
       w.stream()->flush();

--- a/src/hotspot/share/oops/instanceKlass.hpp
+++ b/src/hotspot/share/oops/instanceKlass.hpp
@@ -204,6 +204,9 @@ class InstanceKlass: public Klass {
   // it is stored in the instanceklass as a NULL-terminated UTF-8 string
   const char*     _source_debug_extension;
 
+  // source file path, e.g. /home/xxx/liba.jar
+  Symbol*         _source_file_path;
+
   // Number of heapOopSize words used by non-static fields in this klass
   // (including inherited fields but after header_size()).
   int             _nonstatic_field_size;
@@ -711,6 +714,12 @@ public:
   // source debug extension
   const char* source_debug_extension() const { return _source_debug_extension; }
   void set_source_debug_extension(const char* array, int length);
+
+  Symbol* source_file_path()               { return _source_file_path; }
+  void set_source_file_path(Symbol* value) {
+    _source_file_path = value;
+    if (_source_file_path != NULL) _source_file_path->increment_refcount();
+  }
 
   // nonstatic oop-map blocks
   static int nonstatic_oop_map_size(unsigned int oop_map_count) {

--- a/src/hotspot/share/prims/jvm.cpp
+++ b/src/hotspot/share/prims/jvm.cpp
@@ -2384,6 +2384,18 @@ JVM_ENTRY(jobject, JVM_AssertionStatusDirectives(JNIEnv *env, jclass unused))
   return JNIHandles::make_local(THREAD, asd);
 JVM_END
 
+JVM_ENTRY(jclass, JVM_DefineClassFromCDS(JNIEnv *env, jclass clz, jobject loader, jobject pd, jlong iklass))
+  ResourceMark rm(THREAD);
+  HandleMark hm(THREAD);
+
+  Handle protection_domain (THREAD, JNIHandles::resolve(pd));
+  Handle class_loader (THREAD, JNIHandles::resolve(loader));
+  InstanceKlass* loaded = SystemDictionaryShared::define_class_from_cds((InstanceKlass*) iklass, class_loader,
+                                                                         protection_domain, THREAD);
+
+  return loaded ? (jclass)JNIHandles::make_local(THREAD, loaded->java_mirror()) : NULL;
+JVM_END
+
 // Verification ////////////////////////////////////////////////////////////////////////////////
 
 // Reflection for the verifier /////////////////////////////////////////////////////////////////

--- a/src/hotspot/share/runtime/arguments.cpp
+++ b/src/hotspot/share/runtime/arguments.cpp
@@ -3935,6 +3935,10 @@ jint Arguments::parse(const JavaVMInitArgs* initial_cmd_args) {
     return JNI_EINVAL;
   }
 
+  if (EagerAppCDS && !FLAG_IS_CMDLINE(NotFoundClassOpt)) {
+    NotFoundClassOpt = true;
+  }
+
   // Set object alignment values.
   set_object_alignment();
 

--- a/src/hotspot/share/runtime/globals.hpp
+++ b/src/hotspot/share/runtime/globals.hpp
@@ -2087,7 +2087,12 @@ const intx ObjectAlignmentInBytes = 8;
                                                                             \
   develop(bool, TraceOptimizedUpcallStubs, false,                              \
                 "Trace optimized upcall stub generation")                      \
-
+  product(bool, EagerAppCDS, false,                                         \
+          "aggressively skip over loadClass() to speed up boot time")       \
+  product(bool, EagerAppCDSLegacyVerisonSupport, false, EXPERIMENTAL,       \
+          "dump the classes which is compiled JDK1.5 or below")             \
+  product(bool, NotFoundClassOpt, false,                                    \
+          "optimization for not found class in EagerAppCDS flow")           \
 // end of RUNTIME_FLAGS
 
 DECLARE_FLAGS(LP64_RUNTIME_FLAGS)

--- a/src/hotspot/share/runtime/mutexLocker.cpp
+++ b/src/hotspot/share/runtime/mutexLocker.cpp
@@ -43,6 +43,7 @@ Mutex*   Patching_lock                = NULL;
 Mutex*   CompiledMethod_lock          = NULL;
 Monitor* SystemDictionary_lock        = NULL;
 Mutex*   SharedDictionary_lock        = NULL;
+Mutex*   DumpLoadedClassList_lock     = NULL;
 Monitor* ClassInitError_lock          = NULL;
 Mutex*   Module_lock                  = NULL;
 Mutex*   CompiledIC_lock              = NULL;
@@ -256,6 +257,7 @@ void mutex_init() {
 
   def(SystemDictionary_lock        , PaddedMonitor, leaf,        true,  _safepoint_check_always);
   def(SharedDictionary_lock        , PaddedMutex  , leaf,        true,  _safepoint_check_always);
+  def(DumpLoadedClassList_lock     , PaddedMutex,   leaf,        true,  _safepoint_check_always);     // lookups done by VM thread
   def(ClassInitError_lock          , PaddedMonitor, leaf+1,      true,  _safepoint_check_always);
   def(Module_lock                  , PaddedMutex  , leaf+2,      false, _safepoint_check_always);
   def(InlineCacheBuffer_lock       , PaddedMutex  , leaf,        true,  _safepoint_check_never);

--- a/src/hotspot/share/runtime/mutexLocker.hpp
+++ b/src/hotspot/share/runtime/mutexLocker.hpp
@@ -35,6 +35,7 @@ extern Mutex*   Patching_lock;                   // a lock used to guard code pa
 extern Mutex*   CompiledMethod_lock;             // a lock used to guard a compiled method and OSR queues
 extern Monitor* SystemDictionary_lock;           // a lock on the system dictionary
 extern Mutex*   SharedDictionary_lock;           // a lock on the CDS shared dictionary
+extern Mutex*   DumpLoadedClassList_lock;        // a lock used to guard loaded class dumping
 extern Monitor* ClassInitError_lock;             // a lock on the class initialization error table
 extern Mutex*   Module_lock;                     // a lock on module and package related data structures
 extern Mutex*   CompiledIC_lock;                 // a lock used to guard compiled IC patching and access

--- a/src/java.base/share/classes/com/alibaba/cds/NotFoundClassSet.java
+++ b/src/java.base/share/classes/com/alibaba/cds/NotFoundClassSet.java
@@ -1,0 +1,59 @@
+package com.alibaba.cds;
+
+import sun.security.action.GetPropertyAction;
+
+import java.io.BufferedReader;
+import java.io.FileInputStream;
+import java.io.InputStreamReader;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public class NotFoundClassSet {
+    // The strings should be consistent with those defined in vm
+    // please see in src/hotspot/share/classfile/systemDictionaryShared.hpp
+    private final static String INITIATING_LOADER_STR = "initiating_loader_hash: ";
+    private final static String NOT_FOUND_CLASS_STR = "source: not.found.class";
+
+    private Set<String> notFoundClasses = null;
+    @SuppressWarnings("removal")
+    private NotFoundClassSet() {
+        String notFoundClassList = null;
+        try {
+            notFoundClassList = java.security.AccessController.doPrivileged(
+                    new GetPropertyAction("com.alibaba.cds.listPath"));
+            buildNotFoundClassSet(notFoundClassList);
+        } catch (Exception e) {
+            System.out.println("[CDS Error] init not found map failed to : " + e.toString() + " " + notFoundClassList);
+            e.printStackTrace(System.out);
+        }
+    }
+
+    private static String toKey(String name, int hash) {
+        return name + ":" + Integer.toHexString(hash);
+    }
+
+    public static boolean isNotFound(String name, int hash) {
+        return InstanceHolder.holder.findClass(toKey(name, hash));
+    }
+
+    private void buildNotFoundClassSet(String name) throws Exception {
+        notFoundClasses = new BufferedReader(new InputStreamReader(new FileInputStream(name))).lines()
+                .filter(l -> l.contains(NOT_FOUND_CLASS_STR)).map(line -> {
+                    int tagStart = line.indexOf(INITIATING_LOADER_STR);
+                    assert tagStart != -1;
+                    int end = line.indexOf(" ", tagStart + INITIATING_LOADER_STR.length());
+                    int hash = Integer.parseUnsignedInt(line.substring(tagStart + INITIATING_LOADER_STR.length(), end == -1 ? line.length() : end), 16);
+                    return toKey(line.substring(0, line.indexOf(" ")), hash);
+                }).collect(Collectors.toSet());
+    }
+
+    private boolean findClass(String name) {
+        return notFoundClasses != null && notFoundClasses.contains(name);
+    }
+
+    private static class InstanceHolder {
+        private static final NotFoundClassSet holder = new NotFoundClassSet();
+    }
+}

--- a/src/java.base/share/classes/com/alibaba/util/Utils.java
+++ b/src/java.base/share/classes/com/alibaba/util/Utils.java
@@ -1,0 +1,54 @@
+package com.alibaba.util;
+
+import jdk.internal.misc.JavaLangClassLoaderAccess;
+import jdk.internal.access.SharedSecrets;
+
+import java.lang.ref.WeakReference;
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+public class Utils {
+
+    private static JavaLangClassLoaderAccess JLCA = SharedSecrets.getJavaLangClassLoaderAccess();
+
+    /* For class loader, use WeakReference to avoid additional handling when unloading the class loader
+     * For the entry, in order to ensure the uniqueness during the life cyle of the java process,
+     * it won't be removed when unloading the class loader.
+     * */
+    private static Map<Integer, WeakReference<ClassLoader>> hash2Loader = new ConcurrentHashMap<>();
+
+    public static void registerClassLoader(ClassLoader loader, String identifier) {
+        if (identifier == null || loader == null) {
+            throw new IllegalArgumentException("[Register CL Exception] identifier or loader is null");
+        }
+        try {
+            registerClassLoader(loader, identifier.hashCode());
+        } catch (IllegalStateException e) {
+            throw new IllegalStateException("[Register CL Exception] the identifier " + identifier + " with signature: " +
+                                            Integer.toHexString(identifier.hashCode()) + " has already bean registered for loader " + loader);
+        }
+    }
+
+    public static synchronized void registerClassLoader(ClassLoader loader, int signature) {
+        if (signature == 0) {
+            throw new IllegalArgumentException("[Register CL Exception] signature is zero");
+        }
+        if (JLCA.getSignature(loader) != 0) {
+            throw new IllegalStateException("[Register CL Exception] loader with signature " + Integer.toHexString(signature) +
+                                            " has already bean registered");
+        }
+        if (hash2Loader.containsKey(signature)) {
+            throw new IllegalStateException("[Register CL Exception] has conflict: " + Integer.toHexString(signature) +
+                                            " for loader " + loader);
+        }
+        hash2Loader.put(signature, new WeakReference<>(loader));
+        JLCA.setSignature(loader, signature);
+    }
+
+    private Utils() {}
+    public static WeakReference<ClassLoader> getClassLoader(int signature) {
+        return hash2Loader.get(signature);
+    }
+}

--- a/src/java.base/share/classes/java/lang/ClassLoader.java
+++ b/src/java.base/share/classes/java/lang/ClassLoader.java
@@ -30,6 +30,7 @@ import java.io.InputStream;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.io.File;
+import java.lang.ref.WeakReference;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.net.URL;
@@ -55,6 +56,8 @@ import java.util.function.Supplier;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
+import com.alibaba.util.Utils;
+
 import jdk.internal.loader.BootLoader;
 import jdk.internal.loader.BuiltinClassLoader;
 import jdk.internal.loader.ClassLoaders;
@@ -63,6 +66,8 @@ import jdk.internal.loader.NativeLibraries;
 import jdk.internal.perf.PerfCounter;
 import jdk.internal.misc.Unsafe;
 import jdk.internal.misc.VM;
+import jdk.internal.misc.JavaLangClassLoaderAccess;
+import jdk.internal.access.SharedSecrets;
 import jdk.internal.reflect.CallerSensitive;
 import jdk.internal.reflect.Reflection;
 import jdk.internal.util.StaticProperty;
@@ -232,6 +237,17 @@ public abstract class ClassLoader {
 
     private static native void registerNatives();
     static {
+        SharedSecrets.setJavaLangClassLoaderAccess(new JavaLangClassLoaderAccess() {
+            @Override
+            public int getSignature(ClassLoader cl) {
+                return cl.signature;
+            }
+
+            @Override
+            public void setSignature(ClassLoader cl, int value) {
+                cl.signature = value;
+            }
+        });
         registerNatives();
     }
 
@@ -248,6 +264,9 @@ public abstract class ClassLoader {
 
     // a string for exception message printing
     private final String nameAndId;
+
+    // class loader signature information
+    private int signature;
 
     /**
      * Encapsulates the set of parallel capable loader types.
@@ -637,6 +656,82 @@ public abstract class ClassLoader {
                 return null;
             }
         }
+    }
+
+    /**
+     * load class from Class Data Sharing
+     * 1. use definingLoaderHash to get the defining class loader
+     * 2. use the lock to take care of parallel class loading which is the same as loadClass
+     * 3. use defining class loader to find and define class
+     *
+     * @param  className
+     *         The <a href="#binary-name">binary name</a> of the class
+     *
+     * @param  sourcePath
+     *         the path to load the class
+     *
+     * @param  ik
+     *         instance klass
+     *
+     * @param  definingLoaderHash
+     *         the signature of defining class loader
+     *
+     * @return  The resulting {@code Class} object
+     *
+     * @throws  ClassNotFoundException
+     *          If the class could not be found
+     *
+     */
+    private Class<?> loadClassFromCDS(String className, String sourcePath, long ik,
+                                            int definingLoaderHash) throws ClassNotFoundException {
+        if (signature == 0 || definingLoaderHash == 0) {
+            throw new IllegalArgumentException("[CDS exception]: initialing or defining loader not registered");
+        }
+        ClassLoader definingLoader = this;
+        if (definingLoaderHash != signature) {
+            WeakReference<ClassLoader> loaderRef = Utils.getClassLoader(definingLoaderHash);
+            if (loaderRef == null || loaderRef.get() == null) {
+                throw new IllegalStateException("[CDS exception]: definingLoader " + definingLoaderHash +
+                        " not found, initialing loader is " + this);
+            }
+            definingLoader = loaderRef.get();
+        }
+
+        synchronized (getClassLoadingLock(className)) {
+            synchronized (definingLoader.getClassLoadingLock(className)) {
+                // First, check if the class has already been loaded
+                Class<?> c;
+                if ((c = definingLoader.findLoadedClass(className)) == null) {
+                    long t1 = System.nanoTime();
+                    c = definingLoader.findClassFromCDS(className, sourcePath, ik);
+                    // this is the defining class loader; record the stats
+                    PerfCounter.getFindClassTime().addElapsedTimeFrom(t1);
+                    PerfCounter.getFindClasses().increment();
+                }
+                return c;
+            }
+        }
+    }
+
+    /**
+     * find class in EagerAppCDS flow
+     *
+     * @param  className
+     *         The <a href="#binary-name">binary name</a> of the class
+     *
+     * @param  sourcePath
+     *         The path to load the class
+     *
+     * @param  ik
+     *         instance klass
+     *
+     * @return  The resulting {@code Class} object
+     *
+     * @throws  ClassNotFoundException
+     *          If the class could not be found
+     */
+    protected Class<?> findClassFromCDS(String className, String sourcePath, long ik) throws ClassNotFoundException {
+        return defineClassFromCDS(className, ik, null);
     }
 
     /**
@@ -1104,6 +1199,36 @@ public abstract class ClassLoader {
         postDefineClass(c, protectionDomain);
         return c;
     }
+
+    /**
+     * define class for CDS flow
+     * @param  name
+     *         The expected <a href="#binary-name">binary name</a>. of the class, or
+     *         {@code null} if not known
+     *
+     * @param  protectionDomain
+     *         The {@code ProtectionDomain} of the class, or {@code null}.
+     *
+     * @param  ik
+     *         instance class
+     * @return  The {@code Class} object created from the data,
+     *
+     * @throws  ClassFormatError
+     *          If the data did not contain a valid class.
+     *
+     */
+    protected final Class<?> defineClassFromCDS(String name, long ik, ProtectionDomain protectionDomain)
+        throws ClassFormatError
+    {
+        protectionDomain = preDefineClass(name, protectionDomain);
+        // ignore the code to get source in CDS flow
+        // String source = defineClassSourceLocation(protectionDomain);
+        Class<?> c = defineClassFromCDS0(this, protectionDomain, ik);
+        postDefineClass(c, protectionDomain);
+        return c;
+    }
+
+    static native Class<?> defineClassFromCDS0(ClassLoader loader, ProtectionDomain pd, long iklass);
 
     static native Class<?> defineClass1(ClassLoader loader, String name, byte[] b, int off, int len,
                                         ProtectionDomain pd, String source);

--- a/src/java.base/share/classes/java/net/URLClassLoader.java
+++ b/src/java.base/share/classes/java/net/URLClassLoader.java
@@ -415,6 +415,12 @@ public class URLClassLoader extends SecureClassLoader implements Closeable {
     protected Class<?> findClass(final String name)
         throws ClassNotFoundException
     {
+        return findClassInternal(name, false, null, 0);
+    }
+    @SuppressWarnings("removal")
+    private Class<?> findClassInternal(final String name, boolean eagerAppCDSFastPath, String sourcepath, long ik)
+        throws ClassNotFoundException
+    {
         final Class<?> result;
         try {
             result = AccessController.doPrivileged(
@@ -424,7 +430,11 @@ public class URLClassLoader extends SecureClassLoader implements Closeable {
                         Resource res = ucp.getResource(path, false);
                         if (res != null) {
                             try {
-                                return defineClass(name, res);
+                                if (eagerAppCDSFastPath) {
+                                    return defineClassFromCDS(name, res, ik);
+                                } else {
+                                    return defineClass(name, res);
+                                }
                             } catch (IOException e) {
                                 throw new ClassNotFoundException(name, e);
                             } catch (ClassFormatError e2) {
@@ -476,12 +486,42 @@ public class URLClassLoader extends SecureClassLoader implements Closeable {
         return pkg;
     }
 
+    /**
+     * Finds and loads the class in CDS flow.
+     *
+     * @param name the name of the class
+     *
+     * @param sourcepath the path to load the class
+     *
+     * @param ik instance class
+     *
+     * @return the resulting class
+     *
+     * @exception ClassNotFoundException if the class could not be found,
+     *            or if the loader is closed.
+     */
+    protected Class<?> findClassFromCDS(String name, String sourcepath, long ik)
+        throws ClassNotFoundException {
+        return findClassInternal(name, true, sourcepath, ik);
+    }
+
+    /**
+     * Defines a Class for CDS flow
+     */
+    private Class<?> defineClassFromCDS(String name, Resource res, long ik) throws IOException {
+        return defineClassInternal(name, res, true, ik);
+    }
+
     /*
      * Defines a Class using the class bytes obtained from the specified
      * Resource. The resulting Class must be resolved before it can be
      * used.
      */
     private Class<?> defineClass(String name, Resource res) throws IOException {
+        return defineClassInternal(name, res, false, 0);
+    }
+
+    private Class<?> defineClassInternal(String name, Resource res, boolean eagerAppCDSFastPath, long ik) throws IOException {
         long t0 = System.nanoTime();
         int i = name.lastIndexOf('.');
         URL url = res.getCodeSourceURL();
@@ -506,6 +546,13 @@ public class URLClassLoader extends SecureClassLoader implements Closeable {
                     }
                 }
             }
+        }
+
+        if (eagerAppCDSFastPath) {
+            CodeSigner[] signers = res.getCodeSigners();
+            CodeSource cs = new CodeSource(url, signers);
+            PerfCounter.getReadClassBytesTime().addElapsedTimeFrom(t0);
+            return defineClassFromCDS(name, ik, cs);
         }
         // Now read the class bytes and define the class
         java.nio.ByteBuffer bb = res.getByteBuffer();

--- a/src/java.base/share/classes/java/security/SecureClassLoader.java
+++ b/src/java.base/share/classes/java/security/SecureClassLoader.java
@@ -183,6 +183,21 @@ public class SecureClassLoader extends ClassLoader {
     }
 
     /**
+     * Define a class for CDS flow
+     *
+     * @param       name the expected name of the class
+     *
+     * @param       cs   the associated CodeSource, or {@code null} if none
+     *
+     * @param       ik   instance class
+     *
+     * @return the {@code Class} object created from the data,
+     */
+    protected final Class<?> defineClassFromCDS(String name, long ik, CodeSource cs) {
+        return defineClassFromCDS(name, ik, getProtectionDomain(cs));
+    }
+
+    /**
      * Returns the permissions for the given CodeSource object.
      * <p>
      * This method is invoked by the defineClass method which takes

--- a/src/java.base/share/classes/jdk/internal/access/SharedSecrets.java
+++ b/src/java.base/share/classes/jdk/internal/access/SharedSecrets.java
@@ -41,6 +41,7 @@ import java.io.ObjectInputStream;
 import java.io.RandomAccessFile;
 import java.security.ProtectionDomain;
 import java.security.Signature;
+import jdk.internal.misc.JavaLangClassLoaderAccess;
 
 /** A repository of "shared secrets", which are a mechanism for
     calling implementation-private methods in another package without
@@ -57,6 +58,7 @@ public class SharedSecrets {
     private static JavaAWTFontAccess javaAWTFontAccess;
     private static JavaBeansAccess javaBeansAccess;
     private static JavaLangAccess javaLangAccess;
+    private static JavaLangClassLoaderAccess javaLangClassLoaderAccess;
     private static JavaLangInvokeAccess javaLangInvokeAccess;
     private static JavaLangModuleAccess javaLangModuleAccess;
     private static JavaLangRefAccess javaLangRefAccess;
@@ -120,6 +122,14 @@ public class SharedSecrets {
 
     public static JavaLangAccess getJavaLangAccess() {
         return javaLangAccess;
+    }
+
+    public static void setJavaLangClassLoaderAccess(JavaLangClassLoaderAccess jlca) {
+        javaLangClassLoaderAccess = jlca;
+    }
+
+    public static JavaLangClassLoaderAccess getJavaLangClassLoaderAccess() {
+        return javaLangClassLoaderAccess;
     }
 
     public static void setJavaLangInvokeAccess(JavaLangInvokeAccess jlia) {

--- a/src/java.base/share/classes/jdk/internal/misc/JavaLangClassLoaderAccess.java
+++ b/src/java.base/share/classes/jdk/internal/misc/JavaLangClassLoaderAccess.java
@@ -1,0 +1,9 @@
+package jdk.internal.misc;
+
+import java.lang.ClassLoader;
+
+public interface JavaLangClassLoaderAccess {
+    public int getSignature(ClassLoader cl);
+
+    public void setSignature(ClassLoader cl, int value);
+}

--- a/src/java.base/share/classes/module-info.java
+++ b/src/java.base/share/classes/module-info.java
@@ -129,6 +129,7 @@ module java.base {
     exports javax.security.auth.spi;
     exports javax.security.auth.x500;
     exports javax.security.cert;
+    exports com.alibaba.util;
 
 
     // additional qualified exports may be inserted at build time

--- a/src/java.base/share/native/libjava/ClassLoader.c
+++ b/src/java.base/share/native/libjava/ClassLoader.c
@@ -34,8 +34,13 @@
 #include "java_lang_ClassLoader.h"
 #include <string.h>
 
+#define CLD "Ljava/lang/ClassLoader;"
+#define PD  "Ljava/security/ProtectionDomain;"
+#define CLS "Ljava/lang/Class;"
+
 static JNINativeMethod methods[] = {
-    {"retrieveDirectives",  "()Ljava/lang/AssertionStatusDirectives;", (void *)&JVM_AssertionStatusDirectives}
+    {"retrieveDirectives",  "()Ljava/lang/AssertionStatusDirectives;", (void *)&JVM_AssertionStatusDirectives},
+    {"defineClassFromCDS0", "("CLD PD "J)"CLS,                         (void *)&JVM_DefineClassFromCDS}
 };
 
 JNIEXPORT void JNICALL

--- a/test/jdk/com/alibaba/cds/Classes4CDS.java
+++ b/test/jdk/com/alibaba/cds/Classes4CDS.java
@@ -1,0 +1,418 @@
+import java.io.*;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+public class Classes4CDS {
+    BufferedReader in;
+    PrintStream out;
+
+    static Classes4CDS instance = null;
+    public static Classes4CDS getInstance() {
+        if (instance == null) {
+            instance = new Classes4CDS();
+        }
+        return instance;
+    }
+
+    private Classes4CDS() {}   // prevent created from outside.
+
+    public void setInputStream(BufferedReader input) {
+        in = input;
+    }
+
+    public void setOutputStream(PrintStream prt) {
+        out = prt;
+    }
+
+    boolean status = true; // succeeded
+    public boolean succeeded() { return status; }
+
+    /*
+       exclude: classname contains *$$Lambda$
+                source contains "__JVM_DefineClass__"
+       for classes loaded by bootloader, source is jrt:/java.*
+       struct CDSKlass:  className(String)
+                id(String)
+                superId(String)
+                interFaceIds(String[])
+                source(String)
+
+       ArrayList<CDSKlass) all: contains all the parsed CDS classes
+       HashSet<id, intId>:
+                id is string and unique, intId will be increased by 1;
+                before output, replace id by intId;
+       cond:    if source is jrt:/...  source set to null
+                HashSet<id, className>
+       convert id based on 1 (java/lang/Object)
+
+     */
+
+    int p1 = 0, p2 = 0;  // index for line1 and line2 position.
+
+    class CDSData {
+        public String className;
+        public String id;
+        public String superId;
+        public List<String> interfaceIds;
+        public String source;
+        public String definingHash;
+        public String initiatingHash;
+        public String fingerprint;
+        public CDSData(String name, String id, String superId, List<String> iids, String sourcePath, String definingHash, String fingerprint) {
+            className = name;
+            this.id = id;
+            this.superId = superId;
+            interfaceIds = iids;
+            source = sourcePath;
+            this.definingHash = definingHash;
+            this.initiatingHash = null;
+            this.fingerprint = fingerprint;
+        }
+
+        public CDSData(String name, String sourcePath, String initiatingHash) {
+            className = name;
+            this.id = null;
+            this.superId = null;
+            interfaceIds = null;
+            source = sourcePath;
+            this.definingHash = null;
+            this.initiatingHash = initiatingHash;
+            this.fingerprint = null;
+        }
+
+    }
+
+    private String getKlassName(String line) {
+        int index = 0;
+        while (line.charAt(index) != ' ') index++;
+        String name = line.substring(0, index);
+        return name;
+    }
+
+    private String getKlassPath(String line) {
+        int index = line.indexOf("source:");
+        if (index == -1) {
+            return null;
+        }
+        index += "source:".length();
+        while(line.charAt(index) == ' ') index++;
+        int start = index;
+        while(line.charAt(index) != ' ') index++;
+        String path = line.substring(start, index);
+        return path;
+    }
+
+    private String getId(String line) throws Exception {
+        int index = line.indexOf("klass: ");
+        if (index == -1) {
+            throw new Exception("no Id in line: " + line);
+        }
+        index += "klass: ".length();
+        while(line.charAt(index) == ' ') index++;
+        int start = index;
+        while(index < line.length() && line.charAt(index) != ' ') index++;
+        String id = line.substring(start, index);
+        return id.trim();
+    }
+
+    private String getSuperId(String line) {
+        int index = line.indexOf("super: ");
+        index += "super: ".length();
+        while(line.charAt(index) == ' ') index++;
+        int start = index;
+        while(index < line.length() && line.charAt(index) != ' ') index++;
+        String superId = line.substring(start, index);
+        return superId;
+    }
+
+    private List<String> getInterfaces(String line) {
+        List<String> itfs = new ArrayList<String>();
+        int index = line.indexOf("interfaces: ");
+        if (index == -1) {
+            return itfs;
+        }
+        index += "interfaces: ".length();
+        while(line.charAt(index) == ' ') index++;
+
+        String intfs;
+        // find first alphabet
+        int i;
+        for (i = index; i < line.length(); i++) {
+            if (Character.isAlphabetic(line.charAt(i)) || line.charAt(i) == '_') {
+                break;
+            }
+        }
+        if (i == line.length()) {   // no alphabet anymore
+            intfs = line.substring(index).trim();
+        } else {
+            intfs = line.substring(index, i).trim();
+        }
+
+        String[] iids = intfs.split(" ");
+        for(String s: iids) {
+            itfs.add(s);
+        }
+        return itfs;
+    }
+
+    private String getDefiningLoaderHash(String line) {
+        int index = line.indexOf("defining_loader_hash: ");
+        if (index == -1)  return null;
+        index += "defining_loader_hash: ".length();
+        while(line.charAt(index) == ' ') index++;
+        int start = index;
+        while(index < line.length() && line.charAt(index) != ' ') index++;
+        String hash = line.substring(start, index);
+        return hash;
+    }
+
+    private String getInitiatingLoaderHash(String line) {
+        int index = line.indexOf("initiating_loader_hash: ");
+        if (index == -1)  return null;
+        index += "initiating_loader_hash: ".length();
+        while(line.charAt(index) == ' ') index++;
+        int start = index;
+        while(index < line.length() && line.charAt(index) != ' ') index++;
+        String hash = line.substring(start, index);
+        return hash;
+    }
+
+    private String getFingerprint(String line) {
+        int index = line.indexOf("fingerprint: ");
+        if (index == -1)  return null;
+        index += "fingerprint: ".length();
+        while(line.charAt(index) == ' ') index++;
+        int start = index;
+        while(index < line.length() && line.charAt(index) != ' ') index++;
+        String name = line.substring(start, index);
+        return name;
+    }
+
+    void printCDSData(CDSData data) {
+        out.print(data.className); out.print(" ");
+        out.print("id: " + data.id); out.print(" ");
+
+        if (data.source != null && !data.source.contains("jrt:")) {
+            if (data.superId != null) {
+                out.print("super: " + data.superId);
+                out.print(" ");
+            }
+            if (data.interfaceIds != null && data.interfaceIds.size() != 0) {
+                out.print("interfaces: ");
+                for (String s : data.interfaceIds) {
+                    out.print(s);
+                    out.print(" ");
+                }
+            }
+            out.print("source: " + data.source); out.print(" ");
+            System.out.println(data.source);
+        }
+        if (data.initiatingHash != null) {
+            out.print("initiating_loader_hash: " + data.initiatingHash);
+            out.print(" ");
+        }
+        if (data.definingHash != null) {
+            out.print("defining_loader_hash: " + data.definingHash);
+            out.print(" ");
+        }
+        if (data.fingerprint != null) {
+            out.print("fingerprint: " + data.fingerprint);
+            out.print(" ");
+        }
+        out.println();
+    }
+
+    private void decodeSource(CDSData data) throws Exception {
+        if (data.source == null) {
+            return;
+        }
+        String source = data.source;  // convenience
+        if (source.contains("file:")) {
+            // regular jar case
+            // file:<dir/<main jar>
+            int index = source.indexOf("file:");
+            index += "file:".length();
+            while(source.charAt(index) == ' ') {
+                index++;
+            }
+            data.source = source.substring(index);
+        }
+    }
+
+    private boolean invalidCheck(CDSData data) {
+        if (data.source == null) {
+            return false;
+        }
+        // appCDS
+        if (data.definingHash == null) {
+            if (eagerCDSSet.contains(data.className)) {
+                return true;
+            } else {
+                appCDSSet.add(data.className);
+            }
+        } else {
+            //eagerAppCDS
+            if (data.initiatingHash == null) {
+                return true;
+            } else {
+                if (appCDSSet.contains(data.className)) {
+                    return true;
+                } else {
+                    eagerCDSSet.add(data.className);
+                }
+            }
+        }
+        return false;
+    }
+
+    HashMap<String, String> idIds = new HashMap<String, String>();
+    HashMap<String, CDSData> nameidCDSData = new HashMap<String, CDSData>();
+    HashMap<String, CDSData> notFoundCDSData = new HashMap<String, CDSData>();
+    Set<String> eagerCDSSet = new HashSet<>();
+    Set<String> appCDSSet = new HashSet<>();
+
+    List<CDSData> all = new ArrayList<CDSData>();
+    List<CDSData> allnotfound = new ArrayList<CDSData>();
+
+    void run() {
+        try {
+            String line = in.readLine();
+            while (!line.isEmpty()) {
+                // skip the comment in classlist
+                if(line.charAt(0) != '#') {
+                    if (line.contains("defining_loader_hash:") && line.contains("initiating_loader_hash:")) {
+                        String name = getKlassName(line);
+                        String id = getId(line);
+                        String definingHash = getDefiningLoaderHash(line);
+                        String initiatingHash = getInitiatingLoaderHash(line);
+                        CDSData oldData = nameidCDSData.get(name + id + definingHash);
+                        if (oldData.initiatingHash == null) {
+                            oldData.initiatingHash = initiatingHash;
+                        }
+                    } else if (line.contains("source: not.found.class")) {
+                        String name = getKlassName(line);
+                        String source = getKlassPath(line);
+                        String initiatingHash = getInitiatingLoaderHash(line);
+                        CDSData newData = new CDSData(name, source, initiatingHash);
+                        allnotfound.add(newData);
+                    } else {
+                        String name = getKlassName(line);
+                        String id = getId(line);
+                        String source = getKlassPath(line);
+                        String superId = getSuperId(line);
+                        List<String> iids = getInterfaces(line);
+                        String definingHash = getDefiningLoaderHash(line);
+                        String fingerprint = getFingerprint(line);
+                        CDSData newData = new CDSData(name, id, superId, iids, source, definingHash, fingerprint);
+                        all.add(newData);
+                        nameidCDSData.put(name + id + definingHash, newData);
+                    }
+                }
+                line = in.readLine();
+                if (line == null) {
+                    break;
+                }
+            }
+        } catch (Exception e) {
+            e.printStackTrace();
+            status = false;
+            return;
+        }
+
+        // Now replace Id with incremental numbers
+        // First should be java/lang/Object
+        System.out.println("Total class load: " + all.size());
+        int klassID = 1;
+        CDSData data = all.get(0);
+        if (!data.className.equals("java/lang/Object")) {
+            System.out.println("First should be java/lang/Object!");
+            status = false;
+            return;
+        }
+        data.superId = null;
+        idIds.put(data.id, "1");
+        data.id = String.valueOf(klassID);
+        try {
+            decodeSource(data);
+        } catch (Exception e) {
+            System.out.println("Error happened, Exception is " + e);
+            e.printStackTrace();
+            status = false;
+            return;
+        }
+        printCDSData(data);
+        for (int i = 1; i < all.size(); i++) {
+            data = all.get(i);
+            if (invalidCheck(data)) {
+                continue;
+            }
+            String newId = String.valueOf(++klassID);
+            idIds.put(data.id, newId);
+            data.id = newId;
+            String sp = idIds.get(data.superId);
+            data.superId = sp;
+            if (data.interfaceIds.size() != 0) {
+                for (int j = 0; j < data.interfaceIds.size(); j++) {
+                    String intf = data.interfaceIds.get(j);
+                    String iid = idIds.get(intf);
+                    data.interfaceIds.remove(j);
+                    data.interfaceIds.add(j, iid);
+                }
+            }
+            try {
+                decodeSource(data);
+            } catch (Exception e) {
+                System.out.println("Error happened, Exception is " + e);
+                e.printStackTrace();
+                status = false;
+                return;
+            }
+            printCDSData(data);
+        }
+        for (int i = 0; i < allnotfound.size(); i++) {
+            data = allnotfound.get(i);
+            String name = data.className;
+            if (appCDSSet.contains(name)) {
+                continue;
+            }
+            String newId = String.valueOf(++klassID);
+            data.id = newId;
+            printCDSData(data);
+        }
+    }
+
+    public static void main(String... args) throws Exception {
+        if (args.length != 2) {
+            printHelp();
+        }
+
+        File f  = new File(args[0]);
+        if (!f.exists()) {
+            System.out.println("Non exists input file: " + args[0]);
+            return;
+        }
+        BufferedReader in = new BufferedReader(new FileReader(f));
+        // clean file content
+        PrintWriter pw = new PrintWriter(args[1]);
+        pw.close();
+        PrintStream out   = new PrintStream(args[1]);
+        Classes4CDS cds = Classes4CDS.getInstance();
+        cds.setInputStream(in);
+        cds.setOutputStream(out);
+        cds.run();
+        if (cds.status) {
+            System.out.println("Succeeded!");
+        } else {
+            System.out.println("Failed!");
+            System.exit(-1);
+        }
+    }
+    public static void printHelp() {
+        System.out.println("Usage: ");
+        System.out.println(" <input file> <output file>");
+        System.exit(0);
+    }
+}

--- a/test/jdk/com/alibaba/cds/TestClassLoaderWithSignature.java
+++ b/test/jdk/com/alibaba/cds/TestClassLoaderWithSignature.java
@@ -1,0 +1,37 @@
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import jdk.internal.misc.JavaLangClassLoaderAccess;
+import jdk.internal.access.SharedSecrets;
+
+public class TestClassLoaderWithSignature {
+    private static final Path CLASSES_DIR = Paths.get(System.getProperty("test.classes"));
+
+    public static void main(String... args) throws Exception {
+        //  class loader with name
+        testURLClassLoader("myloader");
+    }
+
+    public static void testURLClassLoader(String loaderName) throws Exception {
+        URL[] urls = new URL[] { CLASSES_DIR.toUri().toURL() };
+        ClassLoader parent = ClassLoader.getSystemClassLoader();
+        URLClassLoader loader = new URLClassLoader(urls, parent);
+
+        try {
+            Method m = Class.forName("com.alibaba.util.Utils").getDeclaredMethod("registerClassLoader",
+                                     ClassLoader.class, String.class);
+            m.setAccessible(true);
+            m.invoke(null, loader, loaderName);
+        } catch (InvocationTargetException e) {
+            e.printStackTrace();
+        }
+
+        Class<?> c = Class.forName("TestSimple", true, loader);
+    }
+
+}
+

--- a/test/jdk/com/alibaba/cds/TestDumpAndLoadClass.java
+++ b/test/jdk/com/alibaba/cds/TestDumpAndLoadClass.java
@@ -1,0 +1,160 @@
+/*
+ * @test
+ * @summary Test dumping with limited metaspace with loading of JVMCI related classes.
+ *          VM should not crash but CDS dump will abort upon failure in allocating metaspace.
+ * @library /lib/testlibrary /test/lib
+ * @modules java.base/jdk.internal.misc
+ *          java.base/jdk.internal.access
+ *          java.management
+ *          jdk.jartool/sun.tools.jar
+ * @modules jdk.compiler
+ * @modules java.base/com.alibaba.util:+open
+ * @build Classes4CDS
+ * @build TestSimple
+ * @build TestClassLoaderWithSignature
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller -jar test.jar TestClassLoaderWithSignature
+ * @run main/othervm -XX:+UnlockExperimentalVMOptions TestDumpAndLoadClass
+ */
+
+import jdk.test.lib.cds.CDSTestUtils;
+import jdk.test.lib.process.OutputAnalyzer;
+import jdk.test.lib.process.ProcessTools;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.io.*;
+
+public class TestDumpAndLoadClass {
+
+    private static final String TESTJAR = "./test.jar";
+    private static final String TESTNAME = "TestClassLoaderWithSignature";
+    private static final String TESTCLASS = TESTNAME + ".class";
+
+    private static final String CLASSLIST_FILE = "./TestDumpAndLoadClass.classlist";
+    private static final String CLASSLIST_FILE_2 = "./TestDumpAndLoadClass.classlist2";
+    private static final String ARCHIVE_FILE = "./TestDumpAndLoadClass.jsa";
+    private static final String BOOTCLASS = "java.lang.Class";
+    private static final String TEST_CLASS = System.getProperty("test.classes"); 
+
+    public static void main(String[] args) throws Exception {
+
+        // dump loaded classes into a classlist file
+        dumpLoadedClasses(new String[] { BOOTCLASS, TESTNAME });
+
+        convertClassList();
+
+        // create an archive using the classlist
+        dumpArchive();
+
+        // start the java process with shared archive file
+        startWithJsa();
+    }
+
+    public static List<String> toClassNames(String filename) throws IOException {
+        ArrayList<String> classes = new ArrayList<>();
+        try (BufferedReader br = new BufferedReader(new InputStreamReader(new FileInputStream(filename)))) {
+            for (; ; ) {
+                String line = br.readLine();
+                if (line == null) {
+                    break;
+                }
+                classes.add(line.replaceAll("/", "."));
+            }
+        }
+        return classes;
+    }
+
+    static void dumpLoadedClasses(String[] expectedClasses) throws Exception {
+        ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(
+            "-Dtest.classes=" + TEST_CLASS,
+            "-XX:DumpLoadedClassList=" + CLASSLIST_FILE,
+            // trigger JVMCI runtime init so that JVMCI classes will be
+            // included in the classlist
+            "-XX:+EagerAppCDS",
+            "-XX:-UseSharedSpaces",
+            "-cp",
+            TESTJAR,
+            TESTNAME);
+
+        OutputAnalyzer output = CDSTestUtils.executeAndLog(pb, "dump-loaded-classes")
+            .shouldHaveExitValue(0);
+
+        List<String> dumpedClasses = toClassNames(CLASSLIST_FILE);
+
+        for (String clazz : expectedClasses) {
+            boolean findString = false;
+            for (String s: dumpedClasses) {
+                if (s.contains(clazz)) {
+                    findString = true;
+                    break;
+                }
+            }
+            if (findString == false) {
+                throw new RuntimeException(clazz + " missing in " +
+                                           CLASSLIST_FILE);
+            }
+        }
+        boolean findString = false;
+        for (String s: dumpedClasses) {
+            if (s.contains("source: file:")) {
+                findString = true;
+                break;
+            }
+        }
+        if (findString == false) {
+            throw new RuntimeException(" there is no class loaded by customer class loader");
+        }
+    }
+
+    static void convertClassList() throws Exception {
+        ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(
+            "Classes4CDS",
+            CLASSLIST_FILE,
+            CLASSLIST_FILE_2);
+
+        OutputAnalyzer output = CDSTestUtils.executeAndLog(pb, "convert-class-list")
+            .shouldHaveExitValue(0);
+
+    }
+    static void dumpArchive() throws Exception {
+        ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(
+            "-cp",
+            TESTJAR,
+            "-Xlog:cds",
+            "-XX:+EagerAppCDS",
+            "-XX:SharedClassListFile=" + CLASSLIST_FILE_2,
+            "-XX:SharedArchiveFile=" + ARCHIVE_FILE,
+            "-Xlog:class+eagerappcds=trace",
+            "-Xshare:dump",
+            "-XX:MetaspaceSize=12M",
+            "-XX:MaxMetaspaceSize=12M");
+
+        OutputAnalyzer output = CDSTestUtils.executeAndLog(pb, "dump-archive");
+        int exitValue = output.getExitValue();
+        if (exitValue == 1) {
+            output.shouldContain("Failed allocating metaspace object type");
+        } else if (exitValue == 0) {
+            output.shouldContain("Loading classes to share");
+        } else {
+            throw new RuntimeException("Unexpected exit value " + exitValue);
+        }
+    }
+
+    static void startWithJsa() throws Exception {
+        ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(
+            "-Dtest.classes=" + TEST_CLASS,
+            "-XX:+EagerAppCDS",
+            "-Xshare:on",
+            "-XX:SharedArchiveFile=" + ARCHIVE_FILE,
+            "-Xlog:class+eagerappcds=trace",
+            "-cp",
+            TESTJAR,
+            TESTNAME);
+
+        OutputAnalyzer output = CDSTestUtils.executeAndLog(pb, "start-with-shared-archive")
+            .shouldHaveExitValue(0);
+        output.shouldNotContain("[CDS load class Failed");
+        output.shouldContain("[CDS load class] Successful loading of class TestSimple with class loader java/net/URLClassLoader");
+    }
+
+}

--- a/test/jdk/com/alibaba/cds/TestDumpAndLoadNotFound.java
+++ b/test/jdk/com/alibaba/cds/TestDumpAndLoadNotFound.java
@@ -1,0 +1,158 @@
+/*
+ * @test
+ * @summary Test dumping with not found class
+ * @library /lib/testlibrary /test/lib
+ * @modules java.base/jdk.internal.misc
+ *          java.management
+ *          jdk.jartool/sun.tools.jar
+ * @modules jdk.compiler
+ * @modules java.base/com.alibaba.util:+open
+ * @build Classes4CDS
+ * @build TestSimple
+ * @build TestLoaderInexistentClass
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller -jar test.jar TestLoaderInexistentClass
+ * @run main/othervm -XX:+UnlockExperimentalVMOptions TestDumpAndLoadNotFound
+ */
+
+import jdk.test.lib.cds.CDSTestUtils;
+import jdk.test.lib.process.OutputAnalyzer;
+import jdk.test.lib.process.ProcessTools;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.io.*;
+
+public class TestDumpAndLoadNotFound {
+
+    private static final String TESTJAR = "./test.jar";
+    private static final String TESTNAME = "TestLoaderInexistentClass";
+    private static final String TESTCLASS = TESTNAME + ".class";
+
+    private static final String CLASSLIST_FILE = "./TestDumpAndLoadNotFound.classlist";
+    private static final String CLASSLIST_FILE_2 = "./TestDumpAndLoadNotFound.classlist2";
+    private static final String ARCHIVE_FILE = "./TestDumpAndLoadNotFound.jsa";
+    private static final String BOOTCLASS = "java.lang.Class";
+    private static final String TEST_CLASS = System.getProperty("test.classes");
+
+    public static void main(String[] args) throws Exception {
+
+        // dump loaded classes into a classlist file
+        dumpLoadedClasses(new String[] { BOOTCLASS, TESTNAME });
+
+        convertClassList();
+
+        // create an archive using the classlist
+        dumpArchive();
+
+        // start the java process with shared archive file
+        startWithJsa();
+    }
+
+    public static List<String> toClassNames(String filename) throws IOException {
+        ArrayList<String> classes = new ArrayList<>();
+        try (BufferedReader br = new BufferedReader(new InputStreamReader(new FileInputStream(filename)))) {
+            for (; ; ) {
+                String line = br.readLine();
+                if (line == null) {
+                    break;
+                }
+                classes.add(line.replaceAll("/", "."));
+            }
+        }
+        return classes;
+    }
+
+    static void dumpLoadedClasses(String[] expectedClasses) throws Exception {
+        ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(
+            "-Dtest.classes=" + TEST_CLASS,
+            "-XX:DumpLoadedClassList=" + CLASSLIST_FILE,
+            // trigger JVMCI runtime init so that JVMCI classes will be
+            // included in the classlist
+            "-XX:+EagerAppCDS",
+            "-XX:-UseSharedSpaces",
+            "-cp",
+            TESTJAR,
+            TESTNAME);
+
+        OutputAnalyzer output = CDSTestUtils.executeAndLog(pb, "dump-loaded-classes")
+            .shouldHaveExitValue(0);
+
+        List<String> dumpedClasses = toClassNames(CLASSLIST_FILE);
+
+        for (String clazz : expectedClasses) {
+            boolean findString = false;
+            for (String s: dumpedClasses) {
+                if (s.contains(clazz)) {
+                    findString = true;
+                    break;
+                }
+            }
+            if (findString == false) {
+                throw new RuntimeException(clazz + " missing in " +
+                                           CLASSLIST_FILE);
+            }
+        }
+        boolean findString = false;
+        for (String s: dumpedClasses) {
+            if (s.contains("source: file:")) {
+                findString = true;
+                break;
+            }
+        }
+        if (findString == false) {
+            throw new RuntimeException(" there is no class loaded by customer class loader");
+        }
+    }
+
+    static void convertClassList() throws Exception {
+        ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(
+            "Classes4CDS",
+            CLASSLIST_FILE,
+            CLASSLIST_FILE_2);
+
+        OutputAnalyzer output = CDSTestUtils.executeAndLog(pb, "convert-class-list")
+            .shouldHaveExitValue(0);
+
+    }
+    static void dumpArchive() throws Exception {
+        ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(
+            "-cp",
+            TESTJAR,
+            "-XX:+EagerAppCDS",
+            "-XX:SharedClassListFile=" + CLASSLIST_FILE_2,
+            "-XX:SharedArchiveFile=" + ARCHIVE_FILE,
+            "-Xlog:class+eagerappcds=trace",
+            "-Xshare:dump",
+            "-XX:MetaspaceSize=12M",
+            "-XX:MaxMetaspaceSize=12M");
+
+        OutputAnalyzer output = CDSTestUtils.executeAndLog(pb, "dump-archive");
+        int exitValue = output.getExitValue();
+        if (exitValue == 1) {
+            output.shouldContain("Failed allocating metaspace object type");
+        } else if (exitValue == 0) {
+            output.shouldContain("Loading classes to share");
+        } else {
+            throw new RuntimeException("Unexpected exit value " + exitValue);
+        }
+    }
+
+    static void startWithJsa() throws Exception {
+        ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(
+            "-Dtest.classes=" + TEST_CLASS,
+            "-XX:+EagerAppCDS",
+            "-Dcom.alibaba.cds.listPath=" + CLASSLIST_FILE_2,
+            "-Xshare:on",
+            "-XX:SharedArchiveFile=" + ARCHIVE_FILE,
+            "-Xlog:class+eagerappcds=trace",
+            "-cp",
+            TESTJAR,
+            TESTNAME);
+
+        OutputAnalyzer output = CDSTestUtils.executeAndLog(pb, "start-with-shared-archive")
+            .shouldHaveExitValue(0);
+        output.shouldNotContain("[CDS load class Failed").shouldContain("[CDS load class] Not found class")
+              .shouldContain("[CDS load class] Successful loading of class");
+    }
+
+}

--- a/test/jdk/com/alibaba/cds/TestLoaderInexistentClass.java
+++ b/test/jdk/com/alibaba/cds/TestLoaderInexistentClass.java
@@ -1,0 +1,63 @@
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+public class TestLoaderInexistentClass {
+    private static final Path CLASSES_DIR = Paths.get(System.getProperty("test.classes"));
+
+    public static void main(String... args) throws Exception {
+        //  class loader with name
+        testURLClassLoader("myloader");
+
+        testURLClassLoader("myloader2");
+
+        testURLClassLoader2("myloader3");
+    }
+
+    public static void testURLClassLoader(String loaderName) throws Exception {
+        URL[] urls = new URL[] { CLASSES_DIR.toUri().toURL() };
+        ClassLoader parent = ClassLoader.getSystemClassLoader();
+        URLClassLoader loader = new URLClassLoader(urls, parent);
+
+        try {
+            Method m = Class.forName("com.alibaba.util.Utils").getDeclaredMethod("registerClassLoader",
+                                     ClassLoader.class, String.class);
+            m.setAccessible(true);
+            m.invoke(null, loader, loaderName);
+        } catch (InvocationTargetException e) {
+            e.printStackTrace();
+        }
+
+        try {
+            Class<?> c = Class.forName("TestSimple", true, loader);
+        } catch (Exception e) {
+        }
+
+        try {
+            Class<?> c2 = Class.forName("TestSimple2", true, loader);
+        } catch (Exception e) {
+        }
+    }
+
+    public static void testURLClassLoader2(String loaderName) throws Exception {
+        URL[] urls = new URL[] { CLASSES_DIR.toUri().toURL() };
+        ClassLoader parent = ClassLoader.getSystemClassLoader();
+        URLClassLoader loader = new URLClassLoader(urls, parent);
+
+        try {
+            Class<?> c = Class.forName("TestSimple", true, loader);
+        } catch (Exception e) {
+        }
+
+        try {
+            Class<?> c2 = Class.forName("TestSimple2", true, loader);
+        } catch (Exception e) {
+        }
+    }
+
+
+}
+

--- a/test/jdk/com/alibaba/cds/TestRegisterClassLoader.java
+++ b/test/jdk/com/alibaba/cds/TestRegisterClassLoader.java
@@ -1,0 +1,96 @@
+/*
+ * @test
+ * @summary Test class loader register in EagerCDS
+ * @library /lib/testlibrary /test/lib
+ * @modules jdk.compiler
+ * @modules java.base/jdk.internal.misc
+ * @modules java.base/jdk.internal.access
+ * @modules java.base/com.alibaba.util:+open
+ * @build jdk.test.lib.compiler.CompilerUtils
+ * @run main/othervm TestRegisterClassLoader
+ */
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import jdk.internal.misc.JavaLangClassLoaderAccess;
+import jdk.internal.access.SharedSecrets;
+
+import jdk.test.lib.process.OutputAnalyzer;
+import jdk.test.lib.process.ProcessTools;
+import jdk.test.lib.compiler.CompilerUtils;
+
+public class TestRegisterClassLoader {
+    private static final String TEST_SRC = System.getProperty("test.src");
+    private static final String SRC_FILENAME = "TestRegisterClassLoader.java";
+
+    private static final Path SRC_DIR = Paths.get(TEST_SRC, "src");
+    private static final Path CLASSES_DIR = Paths.get("classes");
+    private static final String THROW_EXCEPTION_CLASS = "p.ThrowException";
+
+    public static void main(String... args) throws Exception {
+        if (args.length == 0) {
+            ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(
+                        "-Dtest.src=" + TEST_SRC,
+                        "--add-exports=java.base/jdk.internal.misc=ALL-UNNAMED",
+                        "--add-exports=java.base/com.alibaba.util=ALL-UNNAMED",
+                        TestRegisterClassLoader.class.getName(), "1");
+            OutputAnalyzer output = new OutputAnalyzer(pb.start());
+            output.shouldContain("[Register CL Exception] identifier or loader is null")
+                  .shouldContain("[Register CL Exception] the identifier myloader with signature:");
+            return;
+        }
+        /*
+         * Test Register class loader for a class loaded by a named URLClassLoader
+         */
+        compile();
+
+        //  class loader with name
+        testURLClassLoader("myloader");
+
+        //  class loader without name
+        testURLClassLoader(null);
+
+        //  class loader with duplicate name
+        testURLClassLoader("myloader");
+    }
+
+    private static void compile() throws Exception {
+        System.out.println(SRC_DIR + " in " + CLASSES_DIR);
+        boolean rc = CompilerUtils.compile(SRC_DIR, CLASSES_DIR);
+        if (!rc) {
+            throw new RuntimeException("compilation fails" + SRC_DIR + " in " + CLASSES_DIR);
+        }
+    }
+
+    public static void testURLClassLoader(String loaderName) throws Exception {
+        System.err.println("---- test URLClassLoader name: " + loaderName);
+
+        URL[] urls = new URL[] { CLASSES_DIR.toUri().toURL() };
+        ClassLoader parent = ClassLoader.getSystemClassLoader();
+        URLClassLoader loader = new URLClassLoader(urls, parent);
+
+        try {
+            Method m = Class.forName("com.alibaba.util.Utils").getDeclaredMethod("registerClassLoader",
+                                     ClassLoader.class, String.class);
+            m.setAccessible(true);
+            m.invoke(null, loader, loaderName);
+        } catch (InvocationTargetException e) {
+            e.printStackTrace();
+        }
+
+        Class<?> c = Class.forName(THROW_EXCEPTION_CLASS, true, loader);
+        Method method = c.getMethod("throwError");
+        try {
+            // invoke p.ThrowException::throwError
+            method.invoke(null);
+        } catch (InvocationTargetException x) {
+        }
+    }
+
+}
+

--- a/test/jdk/com/alibaba/cds/TestSimple.java
+++ b/test/jdk/com/alibaba/cds/TestSimple.java
@@ -1,0 +1,6 @@
+public class TestSimple {
+    // args[0] = TEST_OUT
+    public static void main(String[] args) {
+        System.out.println(args[0]);
+    }
+}

--- a/test/jdk/com/alibaba/cds/src/p/ThrowException.java
+++ b/test/jdk/com/alibaba/cds/src/p/ThrowException.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package p;
+
+import java.lang.StackWalker.StackFrame;
+
+public class ThrowException {
+    public static void throwError() {
+        throw new Error("testing");
+    }
+}


### PR DESCRIPTION
Summary: add EagerAppCDS support for dw17
	 1. add register API for customer class loader
	 2. add Initiating class loader, Defining class loader, Fingerprint when profiling 
	 3. parse new infos in classlist when dumping, add Initiating class loader, Defining class loader, Source path in jsa 
         4. change `load_instance_class` logic for EagerAppCDS
         5. add NotFoundClass support
         [Warning: No support for the class of the same name, and jtreg test `test/jdk/com/alibaba/cds/TestDumpAndLoadNotFound.java` failed because of this]

Test Plan: ci jtreg cds

Reviewed-by:  yuleil, lingjun-cg

Issue: https://github.com/dragonwell-project/dragonwell17/issues/73