### PR TITLE
[Wisp] Enable CI/CD Github workflows on the wisp branch.

### DIFF
--- a/.github/workflows/submit.yml
+++ b/.github/workflows/submit.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches:
      - master
+     - wisp
   push:
     branches-ignore:
       - master


### PR DESCRIPTION
Summary:

* CI/CD actions will be triggered by pull_request to the wisp branch.

Test Plan: All

Reviewed-by: yulei

Issue: #79 