### PR TITLE
[Wisp] Fix some building and runtime bugs.

### DIFF
--- a/src/hotspot/cpu/x86/interp_masm_x86.cpp
+++ b/src/hotspot/cpu/x86/interp_masm_x86.cpp
@@ -817,11 +817,11 @@ void InterpreterMacroAssembler::jump_from_interpreted(Register method, Register 
     cmpb(Address(temp, JavaThread::interp_only_mode_offset()), 0);
     jccb(Assembler::zero, run_compiled_code);
     if (EnableCoroutine) {
-      cmpq(Address(method, Method::intrinsic_id_offset_in_bytes()), (int32_t)vmIntrinsics::_switchTo);
+      cmpw(Address(method, Method::intrinsic_id_offset_in_bytes()), (int32_t)vmIntrinsics::_switchTo);
       jcc(Assembler::zero, coroutine_skip_interpret);
-      cmpq(Address(method, Method::intrinsic_id_offset_in_bytes()), (int32_t)vmIntrinsics::_switchToAndExit);
+      cmpw(Address(method, Method::intrinsic_id_offset_in_bytes()), (int32_t)vmIntrinsics::_switchToAndExit);
       jcc(Assembler::zero, coroutine_skip_interpret);
-      cmpq(Address(method, Method::intrinsic_id_offset_in_bytes()), (int32_t)vmIntrinsics::_switchToAndTerminate);
+      cmpw(Address(method, Method::intrinsic_id_offset_in_bytes()), (int32_t)vmIntrinsics::_switchToAndTerminate);
       jcc(Assembler::zero, coroutine_skip_interpret);
     }
     jmp(Address(method, Method::interpreter_entry_offset()));

--- a/src/hotspot/cpu/x86/macroAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/macroAssembler_x86.cpp
@@ -1279,11 +1279,6 @@ void MacroAssembler::bang_stack_size(Register size, Register tmp) {
 }
 
 void MacroAssembler::reserved_stack_check() {
-    //TODO: JDK11 introduces the usage of @ReservedStackAccess, we will support it with Coroutine
-    // If we check it in wisp flow, the exception is thrown when coroutine switches.
-    if (EnableCoroutine) {
-        return;
-    }
     // testing if reserved zone needs to be enabled
     Label no_reserved_zone_enabling;
     Register thread = NOT_LP64(rsi) LP64_ONLY(r15_thread);

--- a/src/hotspot/cpu/x86/sharedRuntime_x86_64.cpp
+++ b/src/hotspot/cpu/x86/sharedRuntime_x86_64.cpp
@@ -4153,6 +4153,9 @@ void create_switchTo_contents(MacroAssembler *masm, int start, OopMapSet* oop_ma
       __ movptr(Address(thread, JavaThread::stack_base_offset()), temp);
       __ movl(temp2, Address(target_stack, CoroutineStack::stack_size_offset()));
       __ movl(Address(thread, JavaThread::stack_size_offset()), temp2);
+
+      // update JavaThread::_reserved_stack_activation for @ReservedStackAccess support
+      __ movptr(Address(thread, JavaThread::reserved_stack_activation_offset()), temp);
     }
 #if defined(_WINDOWS)
     {

--- a/src/hotspot/share/gc/shared/barrierSet.cpp
+++ b/src/hotspot/share/gc/shared/barrierSet.cpp
@@ -47,9 +47,10 @@ void BarrierSet::set_barrier_set(BarrierSet* barrier_set) {
          "Expected main thread to be a JavaThread");
   assert(!JavaThread::current()->on_thread_list(),
          "Main thread already on thread list.");
-  _barrier_set->on_thread_create(Thread::current());
+  Thread* thread = Thread::current();
+  _barrier_set->on_thread_create(thread);
   if (UseWispMonitor) {
-    _barrier_set->on_thread_create(WispThread::current(Thread::current()));
+    _barrier_set->on_thread_create(WispThread::current(thread));
   }
 }
 

--- a/src/hotspot/share/runtime/synchronizer.cpp
+++ b/src/hotspot/share/runtime/synchronizer.cpp
@@ -268,10 +268,10 @@ static uintx _no_progress_cnt = 0;
 // into a single notifyAndExit() runtime primitive.
 
 bool ObjectSynchronizer::quick_notify(oopDesc* obj, JavaThread* current, bool all) {
+  assert(current->thread_state() == _thread_in_Java, "invariant");
   if (UseWispMonitor) {
     current = WispThread::current(current);
   }
-  assert(current->thread_state() == _thread_in_Java, "invariant");
   NoSafepointVerifier nsv;
   if (obj == NULL) return false;  // slow-path for invalid obj
   const markWord mark = obj->mark();
@@ -319,10 +319,10 @@ bool ObjectSynchronizer::quick_notify(oopDesc* obj, JavaThread* current, bool al
 
 bool ObjectSynchronizer::quick_enter(oop obj, JavaThread* current,
                                      BasicLock * lock) {
+  assert(UseWispMonitor || current->thread_state() == _thread_in_Java, "invariant");
   if (UseWispMonitor) {
     current = WispThread::current(current);
   }
-  assert(UseWispMonitor || current->thread_state() == _thread_in_Java, "invariant");
   NoSafepointVerifier nsv;
   if (obj == NULL) return false;       // Need to throw NPE
 

--- a/test/hotspot/jtreg/runtime/coroutine/ReservedStackTest.sh
+++ b/test/hotspot/jtreg/runtime/coroutine/ReservedStackTest.sh
@@ -1,0 +1,37 @@
+#!/bin/sh
+
+## @test
+##
+## @requires vm.opt.DeoptimizeALot == null | vm.opt.DeoptimizeALot == false
+## @library /test/lib
+## @summary test \@ReservedStackAccess
+## @run shell ReservedStackTest.sh
+
+set -x
+
+NAME=ReservedStackTest
+PATH=${TESTSRC}/../ReservedStack/${NAME}.java
+MODULES="--add-modules java.base --add-exports java.base/jdk.internal.access=ALL-UNNAMED --add-exports java.base/jdk.internal.vm.annotation=ALL-UNNAMED"
+
+checkexit () {
+    if [ "$?" -ne "0" ] ; then
+      exit 1;
+    fi
+}
+
+if [[ ! -f ${PATH} ]]; then
+  echo "file ${PATH} doesn't exit!"
+  exit 1;
+fi
+
+/usr/bin/cp ${PATH} .
+${COMPILEJAVA}/bin/javac -cp ${TESTSRCPATH} ${MODULES} ${NAME}.java
+
+${COMPILEJAVA}/bin/java -Dtest.jdk=${COMPILEJAVA} -cp ${TESTSRCPATH}:. ${MODULES} -XX:MaxInlineLevel=2 -XX:CompileCommand=exclude,java/util/concurrent/locks/AbstractOwnableSynchronizer.setExclusiveOwnerThread -XX:+EnableCoroutine -XX:+UseWispMonitor -Dcom.alibaba.wisp.transparentWispSwitch=true ${NAME}
+checkexit
+${COMPILEJAVA}/bin/java -Dtest.jdk=${COMPILEJAVA} -cp ${TESTSRCPATH}:. ${MODULES} -XX:MaxInlineLevel=2 -XX:CompileCommand=exclude,java/util/concurrent/locks/AbstractOwnableSynchronizer.setExclusiveOwnerThread -XX:+EnableCoroutine -XX:+UseWispMonitor -Dcom.alibaba.wisp.transparentWispSwitch=true -Dcom.alibaba.wisp.version=2 ${NAME}
+checkexit
+${COMPILEJAVA}/bin/java -Dtest.jdk=${COMPILEJAVA} -cp ${TESTSRCPATH}:. ${MODULES} -XX:+TieredCompilation -XX:TieredStopAtLevel=1 -XX:-Inline -XX:CompileCommand=exclude,java/util/concurrent/locks/AbstractOwnableSynchronizer.setExclusiveOwnerThread -XX:+EnableCoroutine -XX:+UseWispMonitor -Dcom.alibaba.wisp.transparentWispSwitch=true ${NAME}
+checkexit
+${COMPILEJAVA}/bin/java -Dtest.jdk=${COMPILEJAVA} -cp ${TESTSRCPATH}:. ${MODULES} -XX:+TieredCompilation -XX:TieredStopAtLevel=1 -XX:-Inline -XX:CompileCommand=exclude,java/util/concurrent/locks/AbstractOwnableSynchronizer.setExclusiveOwnerThread -XX:+EnableCoroutine -XX:+UseWispMonitor -Dcom.alibaba.wisp.transparentWispSwitch=true -Dcom.alibaba.wisp.version=2 ${NAME}
+checkexit

--- a/test/hotspot/jtreg/runtime/coroutine/coroutineBreakpointSwitchToTest.c
+++ b/test/hotspot/jtreg/runtime/coroutine/coroutineBreakpointSwitchToTest.c
@@ -1,0 +1,48 @@
+#include <jni.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <jvmti.h>
+
+void Jvmti_Error(int errcode, const char *msg) {
+  if (errcode != JVMTI_ERROR_NONE) {
+    printf("%s, error code: [%d]\n", errcode, msg);
+    exit(1);
+  }
+}
+
+#define JVMTI_CHECK(x, str) (Jvmti_Error(x, str))
+
+void JNICALL
+SingleStepCallBack(jvmtiEnv *jvmti_env,
+                   JNIEnv* jni_env,
+                   jthread thread,
+                   jmethodID method,
+                   jlocation location)
+{
+}
+
+JNIEXPORT jint JNICALL
+Agent_OnLoad(JavaVM *jvm, char *options, void *reserved) {
+
+  // 1. get the jvmti env
+  jvmtiEnv *jvmti = NULL;
+  JVMTI_CHECK((*jvm)->GetEnv(jvm, (void **)&jvmti, JVMTI_VERSION_1), "env get error");
+
+  // 2. grant the ability to the jvmti: can single step
+  jvmtiCapabilities noryoku;
+  memset((void *)&noryoku, 0, sizeof(jvmtiCapabilities));
+  noryoku.can_generate_single_step_events = 1;
+  JVMTI_CHECK((*jvmti)->AddCapabilities(jvmti, &noryoku), "add capability error");
+
+  // 3. set: every single step, we can get a notification.
+  JVMTI_CHECK((*jvmti)->SetEventNotificationMode(jvmti, JVMTI_ENABLE, JVMTI_EVENT_SINGLE_STEP, NULL), "set notification failed");
+
+  // 4. when a notification happens, we will get a callback! This callback will booooom.
+  jvmtiEventCallbacks callbacks;
+  memset((void *)&callbacks, 0, sizeof(callbacks));
+  callbacks.SingleStep = &SingleStepCallBack;
+  JVMTI_CHECK((*jvmti)->SetEventCallbacks(jvmti, &callbacks, sizeof(callbacks)), "set callback failed");
+
+  return 0;
+}

--- a/test/hotspot/jtreg/runtime/coroutine/coroutineBreakpointSwitchToTest.sh
+++ b/test/hotspot/jtreg/runtime/coroutine/coroutineBreakpointSwitchToTest.sh
@@ -1,0 +1,45 @@
+#!/bin/sh
+
+#
+# @test
+# @library /testlibrary
+# @compile SimpleWispTest.java
+#
+# @summary test Coroutine SwitchTo() crash problem
+# @run shell coroutineBreakpointSwitchToTest.sh
+#
+
+OS=`uname -s`
+case "$OS" in
+  AIX | Darwin | Linux | SunOS )
+    FS="/"
+    ;;
+  Windows_* )
+    FS="\\"
+    ;;
+  CYGWIN_* )
+    FS="/"
+    ;;
+  * )
+    echo "Unrecognized system!"
+    exit 1;
+    ;;
+esac
+
+JAVA=${TESTJAVA}${FS}bin${FS}java
+
+export LD_LIBRARY_PATH=.:${TESTJAVA}${FS}jre${FS}lib${FS}amd64${FS}server:${FS}usr${FS}lib:${LD_LIBRARY_PATH}
+
+gcc_cmd=`which gcc`
+if [ "x${gcc_cmd}" = "x" ]; then
+    echo "WARNING: gcc not found. Cannot execute test." 2>&1
+    exit 0
+fi
+
+gcc -DLINUX -fPIC -shared -o libtest.so \
+    -I${COMPILEJAVA}/include -I${COMPILEJAVA}/include/linux \
+    ${TESTSRC}/coroutineBreakpointSwitchToTest.c
+
+${JAVA} -agentpath:libtest.so -XX:-UseBiasedLocking -XX:+EnableCoroutine -XX:+UseWispMonitor -Dcom.alibaba.transparentAsync=true -cp ${TESTCLASSES} SimpleWispTest
+
+exit $?

--- a/test/jdk/com/alibaba/wisp/boot/UnsafeDependencyBugTest.java
+++ b/test/jdk/com/alibaba/wisp/boot/UnsafeDependencyBugTest.java
@@ -32,6 +32,6 @@ public class UnsafeDependencyBugTest {
                 .redirectOutput(new File("/dev/null"))
                 .start();
 
-        assertTrue(p.waitFor(2, TimeUnit.SECONDS));
+        assertTrue(p.waitFor(5, TimeUnit.SECONDS));
     }
 }

--- a/test/jdk/java/beans/XMLDecoder/8028054/Task.java
+++ b/test/jdk/java/beans/XMLDecoder/8028054/Task.java
@@ -104,6 +104,7 @@ abstract class Task<T> implements Runnable {
         Predicate<String> startsWithJavaCompiler      = path -> path.toString().startsWith("java.compiler/java");
         Predicate<String> startsWithJavaLogging       = path -> path.toString().startsWith("java.logging/java");
         Predicate<String> startsWithJavaPrefs         = path -> path.toString().startsWith("java.prefs/java");
+        Predicate<String> notStartsWithJavaDyn        = path -> !path.toString().startsWith("java.base/java/dyn");
 
         fileNames = Files.walk(modules)
                 .map(Path::toString)
@@ -121,7 +122,8 @@ abstract class Task<T> implements Runnable {
                     .or(startsWithJavaSQL)
                     .or(startsWithJavaCompiler)
                     .or(startsWithJavaLogging)
-                    .or(startsWithJavaPrefs))
+                    .or(startsWithJavaPrefs)
+                    .and(notStartsWithJavaDyn))
                 .map(s -> s.replace('/', '.'))
                 .filter(path -> path.toString().endsWith(".class"))
                 .map(s -> s.substring(0, s.length() - 6))  // drop .class


### PR DESCRIPTION
This patch consists 5 patches in dragonwell11, see details below.

Original dragonwell11 link:
https://github.com/dragonwell-project/dragonwell11/commit/df998c77aa424fa66f56622833f51861a07a7bb8
https://github.com/dragonwell-project/dragonwell11/commit/24df6e36c4dfcc80c232062fbebac0593a6a8cf2
https://github.com/dragonwell-project/dragonwell11/commit/cca66011a60eb805ec240266970e72841fb4cf57
https://github.com/dragonwell-project/dragonwell11/commit/198a0093e2c5ca4e6bb40e2e529a3c87f0afeb53
https://github.com/dragonwell-project/dragonwell11/commit/662c887f04cb6ebd78fc627beecc69eeffa73d6f

Test Plan: all wisp cases

Reviewed-by: yulei

Issue:
https://github.com/dragonwell-project/dragonwell17/issues/85

---

[Wisp] Add JDK11 @ReservedStackAccess annotation support.

Summary: JavaThread::_reserved_stack_activation is a new Java11 field which caches JavaThread::_stack_base. So we should update it to the stack_base of the new Coroutine when we `switchTo` a new Coroutine. Also tranplant two openjdk tests to wisp.

Test Plan: MultiThread.java, all wisp tests and wisp/reservedstack/*

---

[Wisp] Port change to solve assert failures with slow-debug build.

Summary:
Port change to solving assert failures with slow-debug build commit d09a513ff760382ca18529a0384591bfcd6d1ed0 in AJDK8
To solve the assert failures with slow-debug build
1. Park event issues
When the owner thread is in attaching state, the java thread is not completely initialized. So it should be ignored.
2. Shutdown issue with MultiTenant
For coroutine, the assertion isn't expected. Adjust the order.
3. Shutdown issue without MultiTenant
The exeception is ThreadDeath, not TenantDeathException

Test Plan:
runtime/coroutine/PremainWithWispMonitorTest.java
runtime/coroutine/StealTenantShutdownMaskedCoroutineTest.java
com/alibaba/wisp/shutdown/ShutdownAndCreateNewTask.java
com/alibaba/wisp/shutdown/ShutdownTest.java
com/alibaba/wisp2/Wisp2ShutdownTest.java

---

[Wisp] Fix jvm crash when debugging coroutine switchTo problem.

Summary: Origin patch of the breakpoint crash has a bug, which compares a word-length immediate number and a word-length memory value by using double-word-length comq.

Test Plan: test/runtime/coroutine/coroutineBreakpointSwitchToTest.sh

---

[Wisp] Solve assertion failure related to BarrierSet.

Summary:
The main thread is created before a barrier set is available. The call to BarrierSet::on_thread_create() for the main thread is therefore deferred until it calls BarrierSet::set_barrier_set(). For WispThread in main thread, we should do the same.

Test Plan:
runtime/coroutine/PremainWithWispMonitorTest.java
runtime/coroutine/logCompilationTest.sh

---

[Wisp] modify cases to solve JDK17 failure.

Summary:
1. Task.java
Ignore Task.java for java/dyn package used by coroutine
2. UnsafeDependencyBugTest.java
Timeout issue in different machine. increase the time.

Test Plan:
test/jdk/com/alibaba/wisp/boot/UnsafeDependencyBugTest.java
test/jdk/java/beans/XMLDecoder/8028054/Task.java

---