### PR TITLE
[Wisp] Fix errors and remove useless code. 

### DIFF
--- a/src/hotspot/share/classfile/vmSymbols.hpp
+++ b/src/hotspot/share/classfile/vmSymbols.hpp
@@ -723,10 +723,10 @@
   template(doPrivileged_signature_2,                   "(Ljava/security/PrivilegedAction;Ljava/security/AccessControlContext;)Ljava/lang/Object;")    \
   template(doPrivileged_signature_3,                   "(Ljava/security/PrivilegedExceptionAction;)Ljava/lang/Object;")    \
   template(doPrivileged_signature_4,                   "(Ljava/security/PrivilegedExceptionAction;Ljava/security/AccessControlContext;)Ljava/lang/Object;")    \
-  template(sun_reflect_NativeMethodAccessorImpl,       "sun/reflect/NativeMethodAccessorImpl")                    \
+  template(jdk_internal_reflect_NativeMethodAccessorImpl, "jdk/internal/reflect/NativeMethodAccessorImpl")        \
   template(invoke0_name,                               "invoke0")                                                 \
   template(invoke0_signature,                          "(Ljava/lang/reflect/Method;Ljava/lang/Object;[Ljava/lang/Object;)Ljava/lang/Object;")  \
-  template(sun_reflect_NativeConstructorAccessorImpl,  "sun/reflect/NativeConstructorAccessorImpl")               \
+  template(jdk_internal_reflect_NativeConstructorAccessorImpl, "jdk/internal/reflect/NativeConstructorAccessorImpl") \
   template(newInstance0_signature,                     "(Ljava/lang/reflect/Constructor;[Ljava/lang/Object;)Ljava/lang/Object;")  \
                                                                                                                   \
   /* forEachRemaining support */                                                                                  \

--- a/src/hotspot/share/prims/unsafe.cpp
+++ b/src/hotspot/share/prims/unsafe.cpp
@@ -897,14 +897,7 @@ JVM_ENTRY(void, CoroutineSupport_switchToAndTerminate(JNIEnv* env, jclass klass,
 
   java_dyn_CoroutineBase::set_native_coroutine(old_oop, 0);
 
-  CoroutineStack* stack = coro->stack();
-  stack->remove_from_list(thread->coroutine_stack_list());
-  if (thread->coroutine_stack_cache_size() < MaxFreeCoroutinesCacheSize) {
-    stack->insert_into_list(thread->coroutine_stack_cache());
-    thread->coroutine_stack_cache_size() ++;
-  } else {
-    CoroutineStack::free_stack(stack, thread);
-  }
+  CoroutineStack::free_stack(coro->stack(), thread);
   delete coro;
 JVM_END
 
@@ -922,19 +915,11 @@ JVM_ENTRY(jlong, CoroutineSupport_createCoroutine(JNIEnv* env, jclass klass, job
   if (stack_size == 0 || stack_size < -1) {
     THROW_MSG_0(vmSymbols::java_lang_IllegalArgumentException(), "invalid stack size");
   }
-  CoroutineStack* stack = NULL;
-  if (stack_size <= 0 && thread->coroutine_stack_cache_size() > 0) {
-    stack = thread->coroutine_stack_cache();
-    stack->remove_from_list(thread->coroutine_stack_cache());
-    thread->coroutine_stack_cache_size() --;
-    DEBUG_CORO_ONLY(tty->print("reused coroutine stack at %08x\n", stack->_stack_base));
-  } else {
-    stack = CoroutineStack::create_stack(thread, stack_size);
-    if (stack == NULL) {
-      THROW_0(vmSymbols::java_lang_OutOfMemoryError());
-    }
+
+  CoroutineStack* stack = CoroutineStack::create_stack(thread, stack_size);
+  if (stack == NULL) {
+    THROW_0(vmSymbols::java_lang_OutOfMemoryError());
   }
-  stack->insert_into_list(thread->coroutine_stack_list());
 
   Coroutine* coro = Coroutine::create_coroutine(thread, stack, JNIHandles::resolve(coroutine));
   if (coro == NULL) {
@@ -952,9 +937,7 @@ JVM_ENTRY(jboolean, CoroutineSupport_testDisposableAndTryReleaseStack(JNIEnv* en
 
   jboolean is_disposable = coro->is_disposable();
   if (is_disposable) {
-    CoroutineStack* stack = coro->stack();
-    stack->remove_from_list(thread->coroutine_stack_list());
-    CoroutineStack::free_stack(stack, thread);
+    CoroutineStack::free_stack(coro->stack(), thread);
     delete coro;
   }
   return is_disposable;

--- a/src/hotspot/share/runtime/coroutine.hpp
+++ b/src/hotspot/share/runtime/coroutine.hpp
@@ -427,12 +427,12 @@ public:
   WispStealCandidate (Symbol *holder, Symbol *name, Symbol *signature) : _holder(holder), _name(name), _signature(signature) {}
 private:
   bool is_method_invoke() {
-    return _holder == vmSymbols::sun_reflect_NativeMethodAccessorImpl() && // sun.reflect.NativeMethodAccessorImpl.invoke0()
+    return _holder == vmSymbols::jdk_internal_reflect_NativeMethodAccessorImpl() && // jdk.internal.reflect.NativeMethodAccessorImpl.invoke0()
            _name == vmSymbols::invoke0_name() &&
            _signature == vmSymbols::invoke0_signature();
   }
   bool is_constructor_newinstance() {
-    return _holder == vmSymbols::sun_reflect_NativeConstructorAccessorImpl() &&  // sun.reflect.NativeConstructorAccessorImpl.newInstance0()
+    return _holder == vmSymbols::jdk_internal_reflect_NativeConstructorAccessorImpl() &&  // jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance0()
            _name == vmSymbols::newInstance0_name() &&
            _signature == vmSymbols::newInstance0_signature();
   }

--- a/src/hotspot/share/runtime/globals.hpp
+++ b/src/hotspot/share/runtime/globals.hpp
@@ -2095,9 +2095,6 @@ const intx ObjectAlignmentInBytes = 8;
   product(uintx, DefaultCoroutineStackSize, 128*K,                          \
           "Default size of stack that is associated with new coroutine")    \
                                                                             \
-  product(uintx, MaxFreeCoroutinesCacheSize, 20,                            \
-          "The max number of free coroutine stacks a thread can keep")      \
-                                                                            \
   product(bool, UseWispMonitor, false,                                      \
           "yields to next coroutine when ObjectMonitor is contended")       \
                                                                             \

--- a/src/hotspot/share/runtime/thread.cpp
+++ b/src/hotspot/share/runtime/thread.cpp
@@ -1098,9 +1098,6 @@ JavaThread::JavaThread() :
   _frames_to_pop_failed_realloc(0),
 
   // coroutine support
-  _coroutine_stack_cache(nullptr),
-  _coroutine_stack_cache_size(0),
-  _coroutine_stack_list(nullptr),
   _coroutine_list(nullptr),
   _current_coroutine(nullptr),
   _wisp_preempted(false),
@@ -1262,12 +1259,6 @@ JavaThread::JavaThread(ThreadFunction entry_point, size_t stack_sz) : JavaThread
 }
 
 JavaThread::~JavaThread() {
-  while (EnableCoroutine && coroutine_stack_cache() != NULL) {
-    CoroutineStack* stack = coroutine_stack_cache();
-    stack->remove_from_list(coroutine_stack_cache());
-    CoroutineStack::free_stack(stack, this);
-  }
-
   while (EnableCoroutine && coroutine_list() != NULL) {
      CoroutineStack::free_stack(coroutine_list()->stack(), this);
      delete coroutine_list();
@@ -4150,8 +4141,7 @@ void Threads::verify() {
 
 void JavaThread::initialize_coroutine_support() {
   assert(EnableCoroutine, "EnableCoroutine isn't enable");
-  CoroutineStack::create_thread_stack(this)->insert_into_list(_coroutine_stack_list);
-  Coroutine::create_thread_coroutine(this, _coroutine_stack_list)->insert_into_list(_coroutine_list);
+  Coroutine::create_thread_coroutine(this, CoroutineStack::create_thread_stack(this))->insert_into_list(_coroutine_list);
 }
 
 #ifndef PRODUCT

--- a/src/hotspot/share/runtime/thread.hpp
+++ b/src/hotspot/share/runtime/thread.hpp
@@ -1038,9 +1038,6 @@ class JavaThread: public Thread {
   int _frames_to_pop_failed_realloc;
 
   // coroutine support
-  CoroutineStack*   _coroutine_stack_cache;
-  uintx             _coroutine_stack_cache_size;
-  CoroutineStack*   _coroutine_stack_list;
   Coroutine*        _coroutine_list;
   Coroutine*        _current_coroutine;
   bool              _wisp_preempted;
@@ -1048,9 +1045,6 @@ class JavaThread: public Thread {
   intptr_t          _coroutine_temp;
 
  public:
-  CoroutineStack*& coroutine_stack_cache()       { return _coroutine_stack_cache; }
-  uintx& coroutine_stack_cache_size()            { return _coroutine_stack_cache_size; }
-  CoroutineStack*& coroutine_stack_list()        { return _coroutine_stack_list; }
   Coroutine*& coroutine_list()                   { return _coroutine_list; }
   Coroutine* current_coroutine()                 { return _current_coroutine; }
   void set_current_coroutine(Coroutine *coro)    { _current_coroutine = coro; }

--- a/test/jdk/com/alibaba/wisp2/Wisp2WorkStealTest.java
+++ b/test/jdk/com/alibaba/wisp2/Wisp2WorkStealTest.java
@@ -1,19 +1,58 @@
 /*
  * @test
  * @library /test/lib
- * @summary verification of work stealing really happened
+ * @summary verification of work stealing really happened, also test the several WorkStealCandidates of Wisp2 in different mode: interp/c1/c2
  * @modules java.base/jdk.internal.access
  * @run main/othervm -XX:+UseWisp2 -Dcom.alibaba.wisp.schedule.stealRetry=100 Wisp2WorkStealTest
+ * @run main/othervm -XX:+UseWisp2 -Dcom.alibaba.wisp.schedule.stealRetry=100 -Xcomp -client Wisp2WorkStealTest
+ * @run main/othervm -XX:+UseWisp2 -Dcom.alibaba.wisp.schedule.stealRetry=100 -Xcomp -server Wisp2WorkStealTest
+ * @run main/othervm -XX:+UseWisp2 -Dcom.alibaba.wisp.schedule.stealRetry=100 -Xint Wisp2WorkStealTest
  */
 
 import com.alibaba.wisp.engine.WispEngine;
 import jdk.internal.access.SharedSecrets;
 
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.security.AccessController;
+import java.security.PrivilegedAction;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static jdk.test.lib.Asserts.assertNE;
 
 public class Wisp2WorkStealTest {
+
+    // We have several WispStealCandidates in coroutine.hpp:
+    // in `class WispStealCandidate`:
+    // 1. jdk.internal.reflect.NativeMethodAccessorImpl.invoke0()
+    // 2. jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance0()
+    // 3. java.security.AccessController.doPrivilege(***)
+    // 4. java.lang.Object.wait()
+    // If we support other new candidates, please add them into this test.
+
+    private static void goNatives(Object lock) {
+        AccessController.doPrivileged((PrivilegedAction<Void>)() -> {   // 1. AccessController.doPrivileged() test
+            try {
+                lock.wait();                                            // 2. Object.wait() test
+            } catch (InterruptedException e) {
+                e.printStackTrace();
+            }
+            return null;
+        }, AccessController.getContext());
+    }
+
+    private static class Dummy {
+        public Dummy(Object lock) {
+            try {
+                Method m = Wisp2WorkStealTest.class.getDeclaredMethod("goNatives", Object.class);
+                m.invoke(null, lock);                               // 3. Method.invoke() test
+            } catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException e) {
+                e.printStackTrace();
+            }
+        }
+    }
+
     public static void main(String[] args) {
         Object lock = new Object();
         AtomicReference<Thread> t = new AtomicReference<>();
@@ -22,8 +61,9 @@ public class Wisp2WorkStealTest {
             t.set(SharedSecrets.getJavaLangAccess().currentThread0());
             synchronized (lock) {
                 try {
-                    lock.wait();
-                } catch (InterruptedException e) {
+                    Constructor<Dummy> c = Dummy.class.getConstructor(Object.class);
+                    c.newInstance(lock);                                // 4. Constructor.newInstance() test
+                } catch (NoSuchMethodException | InstantiationException | IllegalAccessException | InvocationTargetException e) {
                     e.printStackTrace();
                 }
             }

--- a/test/jdk/java/dyn/CoroutineTest.java
+++ b/test/jdk/java/dyn/CoroutineTest.java
@@ -207,8 +207,8 @@ public class CoroutineTest {
 		Coroutine.yieldTo(threadCoro);
 	}
 
-  @Test
+	@Test
 	public void destroyNonInitedTest() {
-    new Coroutine();
-  }
+		new Coroutine();
+	}
 }


### PR DESCRIPTION
This patch contains 2 patches in dragonwell11, see details below.

Original dragonwell11 link:
https://github.com/dragonwell-project/dragonwell11/commit/d023f9d9f03847c1745495ca954900f5f0799e57
https://github.com/dragonwell-project/dragonwell11/commit/de7f6efbf56bbaca3315fa171ec1876f30a45b80

Reviewed-by: yulei

---

[Wisp] fix jdk11 module name errors for WispStealCandidates
Summary: jdk11 has module system but WispStealCandidates have the old package name of jdk8

Test Plan: test/jdk/com/alibaba/wisp2/Wisp2WorkStealTest.java

---

[Wisp] Remove useless list of coroutine_stack and coroutine_stack_cache (port to jdk11)

Summary: Remove useless code

Test Plan: all wisp tests

---