### PR TITLE
[Wisp] Port jstack related changes to JDK17.

### DIFF
--- a/src/hotspot/cpu/x86/c1_Runtime1_x86.cpp
+++ b/src/hotspot/cpu/x86/c1_Runtime1_x86.cpp
@@ -1469,7 +1469,12 @@ OopMapSet* Runtime1::generate_code_for(StubID id, StubAssembler* sasm) {
         // Called with store_parameter and not C abi
         f.load_argument(0, rax); // rax,: lock address
         int call_offset;
-        call_offset  = __ call_RT(noreg, noreg, CAST_FROM_FN_PTR(address, monitorexit_wisp_proxy), rax);
+        if (UseWispMonitor) {
+          call_offset  = __ call_RT(noreg, noreg, CAST_FROM_FN_PTR(address, monitorexit_wisp_proxy), rax);
+        } else {
+          call_offset = 0;
+          __ should_not_reach_here();
+        }
         oop_maps = new OopMapSet();
         oop_maps->add_gc_map(call_offset, map);
         restore_live_registers(sasm, save_fpu_registers);

--- a/src/hotspot/share/classfile/javaClasses.cpp
+++ b/src/hotspot/share/classfile/javaClasses.cpp
@@ -4765,6 +4765,7 @@ bool com_alibaba_wisp_engine_WispEngine::in_critical(oop obj) {
 }
 
 int com_alibaba_wisp_engine_WispTask::_jvmParkStatus_offset = 0;
+int com_alibaba_wisp_engine_WispTask::_jdkParkStatus_offset = 0;
 int com_alibaba_wisp_engine_WispTask::_id_offset = 0;
 int com_alibaba_wisp_engine_WispTask::_threadWrapper_offset = 0;
 int com_alibaba_wisp_engine_WispTask::_interrupted_offset = 0;
@@ -4777,6 +4778,7 @@ void com_alibaba_wisp_engine_WispTask::compute_offsets() {
   InstanceKlass* ik = vmClasses::com_alibaba_wisp_engine_WispTask_klass();
   assert(ik != NULL, "WispTask_klass is null");
   compute_offset(_jvmParkStatus_offset, ik, vmSymbols::jvmParkStatus_name(),   vmSymbols::int_signature());
+  compute_offset(_jdkParkStatus_offset, ik, vmSymbols::jdkParkStatus_name(),   vmSymbols::int_signature());
   compute_offset(_id_offset,            ik, vmSymbols::id_name(),              vmSymbols::int_signature());
   compute_offset(_threadWrapper_offset, ik, vmSymbols::threadWrapper_name(),   vmSymbols::thread_signature());
   compute_offset(_interrupted_offset,   ik, vmSymbols::interrupted_name(),     vmSymbols::int_signature());
@@ -4787,7 +4789,15 @@ void com_alibaba_wisp_engine_WispTask::compute_offsets() {
 }
 
 void com_alibaba_wisp_engine_WispTask::set_jvmParkStatus(oop obj, jint status) {
-  return obj->int_field_put(_jvmParkStatus_offset, status);
+  obj->int_field_put(_jvmParkStatus_offset, status);
+}
+
+int com_alibaba_wisp_engine_WispTask::get_jvmParkStatus(oop obj) {
+  return obj->int_field(_jvmParkStatus_offset);
+}
+
+int com_alibaba_wisp_engine_WispTask::get_jdkParkStatus(oop obj) {
+  return obj->int_field(_jdkParkStatus_offset);
 }
 
 int com_alibaba_wisp_engine_WispTask::get_preemptCount(oop obj) {

--- a/src/hotspot/share/classfile/javaClasses.hpp
+++ b/src/hotspot/share/classfile/javaClasses.hpp
@@ -1821,6 +1821,7 @@ public:
 class com_alibaba_wisp_engine_WispTask: AllStatic {
 private:
   static int _jvmParkStatus_offset;
+  static int _jdkParkStatus_offset;
   static int _id_offset;
   static int _threadWrapper_offset;
   static int _interrupted_offset;
@@ -1830,6 +1831,8 @@ private:
   static int _preemptCount_offset;
 public:
   static void set_jvmParkStatus(oop obj, jint status);
+  static int  get_jvmParkStatus(oop obj);
+  static int  get_jdkParkStatus(oop obj);
   static int  get_id(oop obj);
   static oop  get_threadWrapper(oop obj);
   static int  get_interrupted(oop obj);

--- a/src/hotspot/share/classfile/vmSymbols.hpp
+++ b/src/hotspot/share/classfile/vmSymbols.hpp
@@ -693,6 +693,7 @@
   template(com_alibaba_wisp_engine_WispTask,           "com/alibaba/wisp/engine/WispTask")                        \
   template(com_alibaba_wisp_engine_WispEngine,         "com/alibaba/wisp/engine/WispEngine")                      \
   template(isInCritical_name,                          "isInCritical")                                            \
+  template(jdkParkStatus_name,                         "jdkParkStatus")                                           \
   template(jvmParkStatus_name,                         "jvmParkStatus")                                           \
   template(id_name,                                    "id")                                                      \
   template(threadWrapper_name,                         "threadWrapper")                                           \

--- a/src/hotspot/share/opto/graphKit.cpp
+++ b/src/hotspot/share/opto/graphKit.cpp
@@ -851,156 +851,14 @@ static bool should_reexecute_implied_by_bytecode(JVMState *jvms, bool is_anewarr
   }
 }
 
-void GraphKit::add_safepoint_edges_wisp(SafePointNode* call) {
-  assert(UseWispMonitor, "UseWispMonitor is off");
-  // Add the safepoint edges to the call (or other safepoint).
-
-  // Walk the inline list to fill in the correct set of JVMState's
-  // Also fill in the associated edges for each JVMState.
-
-  // If the bytecode needs to be reexecuted we need to put
-  // the arguments back on the stack.
-  const bool should_reexecute = jvms()->should_reexecute();
-  JVMState* youngest_jvms = should_reexecute ? sync_jvms_for_reexecute() : sync_jvms();
-
-  // NOTE: set_bci (called from sync_jvms) might reset the reexecute bit to
-  // undefined if the bci is different.  This is normal for Parse but it
-  // should not happen for LibraryCallKit because only one bci is processed.
-  assert(!is_LibraryCallKit() || (jvms()->should_reexecute() == should_reexecute),
-         "in LibraryCallKit the reexecute bit should not change");
-
-  // If we are guaranteed to throw, we can prune everything but the
-  // input to the current bytecode.
-  bool can_prune_locals = false;
-  uint stack_slots_not_pruned = 0;
-  int inputs = 0, depth = 0;
-
-  if (env()->should_retain_local_variables()) {
-    // At any safepoint, this method can get breakpointed, which would
-    // then require an immediate deoptimization.
-    can_prune_locals = false;  // do not prune locals
-    stack_slots_not_pruned = 0;
-  }
-
-  // do not scribble on the input jvms
-  JVMState* out_jvms = youngest_jvms->clone_deep(C);
-  call->set_jvms(out_jvms); // Start jvms list for call node
-
-  // Presize the call:
-  DEBUG_ONLY(uint non_debug_edges = call->req());
-  call->add_req_batch(top(), youngest_jvms->debug_depth());
-  assert(call->req() == non_debug_edges + youngest_jvms->debug_depth(), "");
-
-  // Set up edges so that the call looks like this:
-  //  Call [state:] ctl io mem fptr retadr
-  //       [parms:] parm0 ... parmN
-  //       [root:]  loc0 ... locN stk0 ... stkSP mon0 obj0 ... monN objN
-  //    [...mid:]   loc0 ... locN stk0 ... stkSP mon0 obj0 ... monN objN [...]
-  //       [young:] loc0 ... locN stk0 ... stkSP mon0 obj0 ... monN objN
-  // Note that caller debug info precedes callee debug info.
-
-  // Fill pointer walks backwards from "young:" to "root:" in the diagram above:
-  uint debug_ptr = call->req();
-
-  // Loop over the map input edges associated with jvms, add them
-  // to the call node, & reset all offsets to match call node array.
-  for (JVMState* in_jvms = youngest_jvms; in_jvms != NULL; ) {
-    uint debug_end   = debug_ptr;
-    uint debug_start = debug_ptr - in_jvms->debug_size();
-    debug_ptr = debug_start;  // back up the ptr
-
-    uint p = debug_start;  // walks forward in [debug_start, debug_end)
-    uint j, k, l;
-    SafePointNode* in_map = in_jvms->map();
-    out_jvms->set_map(call);
-
-    if (can_prune_locals) {
-      assert(in_jvms->method() == out_jvms->method(), "sanity");
-      // If the current throw can reach an exception handler in this JVMS,
-      // then we must keep everything live that can reach that handler.
-      // As a quick and dirty approximation, we look for any handlers at all.
-      if (in_jvms->method()->has_exception_handlers()) {
-        can_prune_locals = false;
-      }
-    }
-
-    // Add the Locals
-    k = in_jvms->locoff();
-    l = in_jvms->loc_size();
-    out_jvms->set_locoff(p);
-    if (!can_prune_locals) {
-      for (j = 0; j < l; j++)
-        call->set_req(p++, in_map->in(k+j));
-    } else {
-      p += l;  // already set to top above by add_req_batch
-    }
-
-    // Add the Expression Stack
-    k = in_jvms->stkoff();
-    l = in_jvms->sp();
-    out_jvms->set_stkoff(p);
-    if (!can_prune_locals) {
-      for (j = 0; j < l; j++)
-        call->set_req(p++, in_map->in(k+j));
-    } else if (can_prune_locals && stack_slots_not_pruned != 0) {
-      // Divide stack into {S0,...,S1}, where S0 is set to top.
-      uint s1 = stack_slots_not_pruned;
-      stack_slots_not_pruned = 0;  // for next iteration
-      if (s1 > l)  s1 = l;
-      uint s0 = l - s1;
-      p += s0;  // skip the tops preinstalled by add_req_batch
-      for (j = s0; j < l; j++)
-        call->set_req(p++, in_map->in(k+j));
-    } else {
-      p += l;  // already set to top above by add_req_batch
-    }
-
-    // Add the Monitors
-    k = in_jvms->monoff();
-    l = in_jvms->mon_size();
-    out_jvms->set_monoff(p);
-    for (j = 0; j < l; j++)
-      call->set_req(p++, in_map->in(k+j));
-
-    // Copy any scalar object fields.
-    k = in_jvms->scloff();
-    l = in_jvms->scl_size();
-    out_jvms->set_scloff(p);
-    for (j = 0; j < l; j++)
-      call->set_req(p++, in_map->in(k+j));
-
-    // Finish the new jvms.
-    out_jvms->set_endoff(p);
-
-    assert(out_jvms->endoff()     == debug_end,             "fill ptr must match");
-    assert(out_jvms->depth()      == in_jvms->depth(),      "depth must match");
-    assert(out_jvms->loc_size()   == in_jvms->loc_size(),   "size must match");
-    assert(out_jvms->mon_size()   == in_jvms->mon_size(),   "size must match");
-    assert(out_jvms->scl_size()   == in_jvms->scl_size(),   "size must match");
-    assert(out_jvms->debug_size() == in_jvms->debug_size(), "size must match");
-
-    // Update the two tail pointers in parallel.
-    out_jvms = out_jvms->caller();
-    in_jvms  = in_jvms->caller();
-  }
-
-  assert(debug_ptr == non_debug_edges, "debug info must fit exactly");
-
-  // Test the correctness of JVMState::debug_xxx accessors:
-  assert(call->jvms()->debug_start() == non_debug_edges, "");
-  assert(call->jvms()->debug_end()   == call->req(), "");
-  assert(call->jvms()->debug_depth() == call->req() - non_debug_edges, "");
-}
-
-
 // Helper function for adding JVMState and debug information to node
-void GraphKit::add_safepoint_edges(SafePointNode* call, bool must_throw) {
+void GraphKit::add_safepoint_edges(SafePointNode* call, bool must_throw, bool is_wisp) {
   // Add the safepoint edges to the call (or other safepoint).
 
   // Make sure dead locals are set to top.  This
   // should help register allocation time and cut down on the size
   // of the deoptimization information.
-  assert(dead_locals_are_killed(), "garbage in debug info before safepoint");
+  assert(is_wisp || dead_locals_are_killed(), "garbage in debug info before safepoint");
 
   // Walk the inline list to fill in the correct set of JVMState's
   // Also fill in the associated edges for each JVMState.
@@ -1042,7 +900,7 @@ void GraphKit::add_safepoint_edges(SafePointNode* call, bool must_throw) {
 
   // For a known set of bytecodes, the interpreter should reexecute them if
   // deoptimization happens. We set the reexecute state for them here
-  if (out_jvms->is_reexecute_undefined() && //don't change if already specified
+  if (!is_wisp && out_jvms->is_reexecute_undefined() && //don't change if already specified
       should_reexecute_implied_by_bytecode(out_jvms, call->is_AllocateArray())) {
 #ifdef ASSERT
     int inputs = 0, not_used; // initialized by GraphKit::compute_stack_effects()
@@ -3755,7 +3613,7 @@ void GraphKit::shared_unlock(Node* box, Node* obj) {
   unlock = _gvn.transform(unlock)->as_Unlock();
 
   if (UseWispMonitor && jvms()->has_method()) {
-    add_safepoint_edges_wisp(unlock);
+    add_safepoint_edges(unlock, false, true);
   }
   Node* mem = reset_memory();
 

--- a/src/hotspot/share/opto/graphKit.hpp
+++ b/src/hotspot/share/opto/graphKit.hpp
@@ -286,9 +286,8 @@ class GraphKit : public Phase {
   // The call may deoptimize.  Supply required JVM state as debug info.
   // If must_throw is true, the call is guaranteed not to return normally.
   void add_safepoint_edges(SafePointNode* call,
-                           bool must_throw = false);
+                           bool must_throw = false, bool is_wisp = false);
 
-  void add_safepoint_edges_wisp(SafePointNode* call);
   // How many stack inputs does the current BC consume?
   // And, how does the stack change after the bytecode?
   // Returns false if unknown.

--- a/src/hotspot/share/runtime/coroutine.cpp
+++ b/src/hotspot/share/runtime/coroutine.cpp
@@ -436,26 +436,45 @@ frame CoroutineStack::last_frame(Coroutine* coro, RegisterMap& map) const {
   return frame(sp, fp, pc);
 }
 
+oop Coroutine::print_stack_header_on(outputStream* st) {
+  oop thread_obj = NULL;
+  st->print("\n - Coroutine [%p]", this);
+  if (_wisp_task != NULL) {
+    thread_obj = com_alibaba_wisp_engine_WispTask::get_threadWrapper(_wisp_task);
+    char buf[128] = "<cached>";
+    if (thread_obj != NULL) {
+      oop name = java_lang_Thread::name(thread_obj);
+      if (name != NULL) {
+        java_lang_String::as_utf8_string(name, buf, sizeof(buf));
+      }
+    }
+    st->print(" \"%s\" #%d active=%d steal=%d steal_fail=%d preempt=%d park=%d/%d", buf,
+        com_alibaba_wisp_engine_WispTask::get_id(_wisp_task),
+        com_alibaba_wisp_engine_WispTask::get_activeCount(_wisp_task),
+        com_alibaba_wisp_engine_WispTask::get_stealCount(_wisp_task),
+        com_alibaba_wisp_engine_WispTask::get_stealFailureCount(_wisp_task),
+        com_alibaba_wisp_engine_WispTask::get_preemptCount(_wisp_task),
+        com_alibaba_wisp_engine_WispTask::get_jvmParkStatus(_wisp_task),
+        com_alibaba_wisp_engine_WispTask::get_jdkParkStatus(_wisp_task));
+  }
+  if (_wisp_thread && PrintThreadCoroutineInfo) {
+    st->print(" monitor_park_stage=%s", WispThread::print_blocking_status(_wisp_thread->_unpark_status));
+    if (_wisp_thread->_os_park_reason != WispThread::_not_os_park) {
+      st->print(" os_park_reason=%s", WispThread::print_os_park_reason(_wisp_thread->_os_park_reason));
+    }
+    if (_wisp_thread->_unpark_coroutine) {
+      st->print(" unpark_thread=%p", _wisp_thread->_unpark_coroutine);
+      if (_wisp_thread->_has_exception) {
+        st->print(" (unpark has exception)");
+      }
+    }
+  } // else, we're only using the JKU part
+  return thread_obj;
+}
+
 void Coroutine::print_stack_on(outputStream* st) {
   if (_state == Coroutine::_onstack) {
-    oop thread_obj = NULL;
-    st->print("\n - Coroutine [%p]", this);
-    if (_wisp_task != NULL) {
-      thread_obj = com_alibaba_wisp_engine_WispTask::get_threadWrapper(_wisp_task);
-      char buf[128] = "<cached>";
-      if (thread_obj != NULL) {
-        oop name = java_lang_Thread::name(thread_obj);
-        if (name != NULL) {
-          java_lang_String::as_utf8_string(name, buf, sizeof(buf));
-        }
-      }
-      st->print(" \"%s\" #%d active=%d steal=%d steal_fail=%d preempt=%d", buf,
-          com_alibaba_wisp_engine_WispTask::get_id(_wisp_task),
-          com_alibaba_wisp_engine_WispTask::get_activeCount(_wisp_task),
-          com_alibaba_wisp_engine_WispTask::get_stealCount(_wisp_task),
-          com_alibaba_wisp_engine_WispTask::get_stealFailureCount(_wisp_task),
-          com_alibaba_wisp_engine_WispTask::get_preemptCount(_wisp_task));
-    } // else, we're only using the JKU part
+    oop thread_obj = print_stack_header_on(st);
     st->print("\n");
 
     ResourceMark rm;
@@ -542,6 +561,47 @@ void WispThread::set_wisp_booted(JavaThread* thread) {
  *   So , totally disable the switch in PLL is better solution(monitor->object() != java_lang_ref_Reference::pending_list_lock()).
  *
 */
+
+bool WispThread::need_wisp_park(ObjectMonitor* monitor, ObjectWaiter* ow, bool is_sd_lock) {
+  _os_park_reason = _not_os_park;
+  _unpark_status = _no_park;
+
+  if (!_wisp_booted) {
+    _os_park_reason = _wisp_not_booted;
+    return false;
+  }
+  if (_coroutine->wisp_task_id() == Coroutine::WISP_ID_NOT_SET) {
+    // For java threads, including JvmtiAgentThread, ServiceThread,
+    // SurrogateLockerThread, CompilerThread which are only used in JVM,
+    // because we don't initialize co-routine stuff for them, the initial
+    // value of _coroutine->wisp_task_id() for them should be Coroutine::WISP_ID_NOT_SET.
+    _os_park_reason = _wisp_id_not_set;
+    return false;
+  }
+  if (com_alibaba_wisp_engine_WispEngine::in_critical(_coroutine->wisp_engine())) {
+    _os_park_reason = _wispengine_in_critical;
+    return false;
+  }
+  if (_thread->in_critical()) {
+    _os_park_reason = _thread_in_critical;
+    return false;
+  }
+  if (Compile_lock->owner() == _thread) {
+    // case holding Compile_lock, we will park for lock contention
+    // not for monitor->wait()
+    // so we'll be unparked immediately. It's safe to block the JavaThread
+    _os_park_reason = _thread_owned_compile_lock;
+    return false;
+  }
+  if (is_sd_lock && ow->TState != ObjectWaiter::TS_WAIT) {
+    // case parking for fetching SystemDictionary_lock fails, DO NOT schedule
+    // otherwise we'll encounter DEADLOCK because of fetching CompilerQeueu_lock in java
+    _os_park_reason = _is_sd_lock;
+    return false;
+  }
+  return true;
+}
+
 void WispThread::before_enqueue(ObjectMonitor* monitor, ObjectWaiter* ow) {
   JavaThreadState st = _thread->_thread_state;
   if (st != _thread_in_vm) {
@@ -549,22 +609,7 @@ void WispThread::before_enqueue(ObjectMonitor* monitor, ObjectWaiter* ow) {
     ThreadStateTransition::transition(_thread, st, _thread_in_vm);
   }
   bool is_sd_lock = monitor->object() == SystemDictionary_lock->obj();
-  if (_wisp_booted && _coroutine->wisp_task_id() != Coroutine::WISP_ID_NOT_SET
-      // For java threads, including JvmtiAgentThread, ServiceThread,
-      // SurrogateLockerThread, CompilerThread which are only used in JVM,
-      // because we don't initialize co-routine stuff for them, the initial
-      // value of _coroutine->wisp_task_id() for them should be Coroutine::WISP_ID_NOT_SET.
-      && !com_alibaba_wisp_engine_WispEngine::in_critical(_coroutine->wisp_engine())
-      //&& monitor->object() != java_lang_ref_Reference::pending_list_lock()
-      && !_thread->in_critical()
-      && Compile_lock->owner() != _thread
-      // case holding Compile_lock,  we will park for lock contention
-      // not for monitor->wait()
-      // so we'll be unparked immediately. It's safe to block the JavaThread 
-      && !(is_sd_lock && ow->TState != ObjectWaiter::TS_WAIT)
-      // case parking for fetching SystemDictionary_lock fails, DO NOT schedule
-      // otherwise we'll encounter DEADLOCK because of fetching CompilerQeueu_lock in java
-      ) {
+  if (need_wisp_park(monitor, ow, is_sd_lock)) {
     ow->_using_wisp_park = true;
     ow->_park_wisp_id = _coroutine->wisp_task_id();
     com_alibaba_wisp_engine_WispTask::set_jvmParkStatus(_coroutine->wisp_task(), 0); //reset
@@ -592,7 +637,7 @@ void WispThread::park(long millis, const ObjectWaiter* ow) {
     millis = ow->_timeout;
     assert(!ow->_using_wisp_park, "invariant");
   }
-
+  WispThread* wisp_thread = (WispThread*) ow->_thread;
   if (ow->_using_wisp_park) {
     assert(parkMethod != NULL, "parkMethod should be resolved in set_wisp_booted");
 
@@ -604,7 +649,7 @@ void WispThread::park(long millis, const ObjectWaiter* ow) {
 
     // thread steal support
     WispPostStealHandleUpdateMark w(jt);   // special one, because park() is inside an EnableStealMark, so the _enable_steal_count counter has been added one.
-
+    wisp_thread->_unpark_status = _wisp_parking;
     // when TenantThreadStop is on, we may receive TenantDeathException
     // and return before unpark().
     // Do not use a TenantShutdownMark to change the behavior.
@@ -618,6 +663,7 @@ void WispThread::park(long millis, const ObjectWaiter* ow) {
 
     ThreadStateTransition::transition(jt, _thread_in_vm, _thread_blocked);
   } else {
+    wisp_thread->_unpark_status = _os_parking;
     if (millis <= 0) {
       ow->_event->park();
     } else {
@@ -626,8 +672,11 @@ void WispThread::park(long millis, const ObjectWaiter* ow) {
   }
 }
 
-void WispThread::unpark(int task_id, bool using_wisp_park, bool proxy_unpark, ParkEvent* event, TRAPS) {
+void WispThread::unpark(int task_id, bool using_wisp_park, bool proxy_unpark, ParkEvent* event, WispThread* wisp_thread, TRAPS) {
+  wisp_thread->_has_exception = false;
+  wisp_thread->_unpark_coroutine = NULL;
   if (!using_wisp_park) {
+    wisp_thread->_unpark_status = _os_unpark;
     event->unpark();
     return;
   }
@@ -639,6 +688,7 @@ void WispThread::unpark(int task_id, bool using_wisp_park, bool proxy_unpark, Pa
   WispThread* wt = WispThread::current(THREAD);
   proxy_unpark_special_case = wt->is_proxy_unpark();
   wt->clear_proxy_unpark_flag();
+  wisp_thread->_unpark_coroutine = jt->current_coroutine();
 
   if (proxy_unpark || proxy_unpark_special_case ||
       jt->is_Compiler_thread() ||
@@ -655,11 +705,14 @@ void WispThread::unpark(int task_id, bool using_wisp_park, bool proxy_unpark, Pa
     // due to the fact that we modify the priority of Wisp_lock from `non-leaf` to `special`,
     // so we'd use `MutexLocker` and `_no_safepoint_check_flag` to make our program run
     MutexLocker mu(Wisp_lock, Mutex::_no_safepoint_check_flag);
+    wisp_thread->_unpark_status = WispThread::_proxy_unpark_begin;
     _proxy_unpark->append(task_id);
     Wisp_lock->notify(); // only one consumer
+    wisp_thread->_unpark_status = WispThread::_proxy_unpark_done;
     return;
   }
 
+  wisp_thread->_unpark_status = WispThread::_wisp_unpark_begin;
   JavaValue result(T_VOID);
   JavaCallArguments args;
   args.push_int(task_id);
@@ -684,11 +737,14 @@ void WispThread::unpark(int task_id, bool using_wisp_park, bool proxy_unpark, Pa
   {
     // unpark is very important, should not interruted by tenant shutdown
     assert(unparkMethod != NULL, "unparkMethod should be resolved in set_wisp_booted");
+    wisp_thread->_unpark_status = WispThread::_wisp_unpark_before_call_java;
     JavaCalls::call(&result, methodHandle(Thread::current(), unparkMethod), &args, jt);
+    wisp_thread->_unpark_status = WispThread::_wisp_unpark_after_call_java;
   }
   // ~tsm may produce an exception and c1 monitor_exit has an exception_mark
   // clear the exception to prevent jvm crash
   if (jt->has_pending_exception()) {
+    wisp_thread->_has_exception = true;
     jt->clear_pending_exception();
   }
   if (in_java) {
@@ -697,6 +753,7 @@ void WispThread::unpark(int task_id, bool using_wisp_park, bool proxy_unpark, Pa
   if (pending_excep != NULL) {
     jt->set_pending_exception(pending_excep, pending_file, pending_line);
   }
+  wisp_thread->_unpark_status = WispThread::_wisp_unpark_done;
 }
 
 int WispThread::get_proxy_unpark(jintArray res) {
@@ -747,6 +804,56 @@ void WispThread::interrupt(int task_id, TRAPS) {
       &args,
       THREAD);
 
+}
+
+const char* WispThread::print_os_park_reason(int reason) {
+  switch(reason) {
+  case _not_os_park:
+    return "NOT_OS_PARK";
+  case _wisp_not_booted:
+    return "WISP_NOT_BOOOTED";
+  case _wisp_id_not_set:
+    return "WISP_ID_NOT_SET";
+  case _wispengine_in_critical:
+    return "WISPENGINE_IN_CRITICAL";
+  case _monitor_is_pending_lock:
+    return "MONITOR_IS_PENDING_LOCK";
+  case _thread_in_critical:
+    return "THREAD_IN_CRITICAL";
+  case _thread_owned_compile_lock:
+    return "THREAD_OWNED_COMPILE_LOCK";
+  case _is_sd_lock:
+    return "IS_SD_LOCK";
+  default:
+    return "";
+  }
+}
+
+const char* WispThread::print_blocking_status(int status) {
+  switch(status) {
+  case _no_park:
+    return "NO_PARK";
+  case _wisp_parking:
+    return "WISP_PARKING";
+  case _os_parking:
+    return "OS_PARKING";
+  case _wisp_unpark_begin:
+    return "WISP_UNPARK_BEGIN";
+  case _wisp_unpark_before_call_java:
+    return "WISP_UNPARK_BEFORE_CALL_JAVA";
+  case _wisp_unpark_after_call_java:
+    return "WISP_UNPARK_AFTER_CALL_JAVA";
+  case _wisp_unpark_done:
+    return "WISP_UNPARK_DONE";
+  case _proxy_unpark_begin:
+    return "PROXY_UNPARK_BEGIN";
+  case _proxy_unpark_done:
+    return "PROXY_UNPARK_DONE";
+  case _os_unpark:
+    return "OS_UNPARK";
+  default:
+    return "";
+  }
 }
 
 void Coroutine::after_safepoint(JavaThread* thread) {

--- a/src/hotspot/share/runtime/coroutine.hpp
+++ b/src/hotspot/share/runtime/coroutine.hpp
@@ -205,6 +205,7 @@ public:
 
   bool is_disposable();
 
+  oop print_stack_header_on(outputStream* st);
   void print_stack_on(outputStream* st);
 
   // GC support
@@ -348,10 +349,19 @@ private:
   JavaThread* _thread;
 
   bool _is_proxy_unpark;
+  int _unpark_status;
+  int _os_park_reason;
+  bool _has_exception;
+
+  Coroutine* _unpark_coroutine;
 
   WispThread(Coroutine *c): _coroutine(c), _thread(c->thread()), _is_proxy_unpark(false) {
     set_osthread(new OSThread(NULL, NULL));
     set_thread_state(_thread_in_vm);
+    _unpark_status = 0;
+    _os_park_reason = 0;
+    _has_exception = false;
+    _unpark_coroutine = NULL;
   }
 
   virtual ~WispThread() {
@@ -360,8 +370,34 @@ private:
   }
 
 public:
+  enum OsParkReason {
+    _not_os_park = 0,
+    _wisp_not_booted = 1,
+    _wisp_id_not_set = 2,
+    _wispengine_in_critical = 3,
+    _monitor_is_pending_lock = 4,
+    _thread_in_critical = 5,
+    _thread_owned_compile_lock = 6,
+    _is_sd_lock = 7
+  };
+
+  enum BlockingStatus {
+    _no_park = 0,
+    _wisp_parking = 1,
+    _os_parking = 2,
+    _wisp_unpark_begin = 3,
+    _wisp_unpark_before_call_java = 4,
+    _wisp_unpark_after_call_java = 5,
+    _wisp_unpark_done = 6,
+    _proxy_unpark_begin = 7,
+    _proxy_unpark_done = 8,
+    _os_unpark = 9
+  };
+
   static bool wisp_booted()           { return _wisp_booted; }
   static void set_wisp_booted(JavaThread* thread);
+  static const char *print_os_park_reason(int reason);
+  static const char *print_blocking_status(int status);
 
   virtual bool is_Wisp_thread() const { return true; }
 
@@ -388,11 +424,12 @@ public:
 
   // we must set ObjectWaiter members before node enqueued(observed by other threads)
   void before_enqueue(ObjectMonitor* monitor, ObjectWaiter* ow);
+  bool need_wisp_park(ObjectMonitor* monitor, ObjectWaiter* ow, bool is_sd_lock);
   static void park(long millis, const ObjectWaiter* ow);
   static void unpark(const ObjectWaiter* ow, TRAPS) {
-    unpark(ow->_park_wisp_id, ow->_using_wisp_park, ow->_proxy_wisp_unpark, ow->_event, THREAD);
+    unpark(ow->_park_wisp_id, ow->_using_wisp_park, ow->_proxy_wisp_unpark, ow->_event, (WispThread*)ow->_thread, THREAD);
   }
-  static void unpark(int task_id, bool using_wisp_park, bool proxy_unpark, ParkEvent* event, TRAPS);
+  static void unpark(int task_id, bool using_wisp_park, bool proxy_unpark, ParkEvent* event, WispThread* wisp_thread, TRAPS);
   static int get_proxy_unpark(jintArray res);
 
   static WispThread* current(Thread* thread) {

--- a/src/hotspot/share/runtime/globals.hpp
+++ b/src/hotspot/share/runtime/globals.hpp
@@ -2101,6 +2101,9 @@ const intx ObjectAlignmentInBytes = 8;
   product(bool, UseWisp2, false,                                            \
           "Enable Wisp2")                                                   \
                                                                             \
+  product(bool, PrintThreadCoroutineInfo, false, MANAGEABLE,                \
+          "print the park/unpark information for thread coroutine")         \
+                                                                            \
 
 
 // end of RUNTIME_FLAGS

--- a/src/hotspot/share/runtime/objectMonitor.cpp
+++ b/src/hotspot/share/runtime/objectMonitor.cpp
@@ -1373,6 +1373,7 @@ void ObjectMonitor::ExitEpilog(JavaThread* current, ObjectWaiter* Wakee) {
   const int  wisp_id  = Wakee->_park_wisp_id;
   const bool use_wisp = Wakee->_using_wisp_park;
   const bool proxy_unpark = Wakee->_proxy_wisp_unpark;
+  WispThread* wisp_thread = (WispThread*)Wakee->_thread;
 
 
   // Hygiene -- once we've set _owner = NULL we can't safely dereference Wakee again.
@@ -1387,7 +1388,7 @@ void ObjectMonitor::ExitEpilog(JavaThread* current, ObjectWaiter* Wakee) {
 
   DTRACE_MONITOR_PROBE(contended__exit, this, object(), current);
   if (UseWispMonitor) {
-    WispThread::unpark(wisp_id, use_wisp, proxy_unpark, Trigger, current);
+    WispThread::unpark(wisp_id, use_wisp, proxy_unpark, Trigger, wisp_thread, current);
   } else {
     Trigger->unpark();
   }

--- a/src/hotspot/share/runtime/thread.cpp
+++ b/src/hotspot/share/runtime/thread.cpp
@@ -3952,6 +3952,10 @@ void Threads::print_on(outputStream* st, bool print_stacks,
         p->print_stack_on(st);
         if (EnableCoroutine) {
           assert(p->coroutine_list() != NULL, "coroutine list");
+          if (!p->is_Compiler_thread() && (PrintThreadCoroutineInfo || !p->current_coroutine()->is_thread_coroutine())) {
+            p->current_coroutine()->print_stack_header_on(st);
+            st->print("\n");
+          }
           Coroutine* c = p->coroutine_list();
           do {
             c->print_stack_on(st);

--- a/src/hotspot/share/runtime/vframe.cpp
+++ b/src/hotspot/share/runtime/vframe.cpp
@@ -248,7 +248,7 @@ void javaVFrame::print_lock_info_on(outputStream* st, int frame_count) {
         // the monitor is associated with an object, i.e., it is locked
 
         const char *lock_state = "locked"; // assume we have the monitor locked
-        if (!found_first_monitor && frame_count == 0 || UseWispMonitor) {
+        if (!found_first_monitor && (frame_count == 0 || UseWispMonitor)) {
           // If this is the first frame and we haven't found an owned
           // monitor before, then we need to see if we have completed
           // the lock or if we are blocked trying to acquire it. Only

--- a/src/hotspot/share/runtime/vmOperation.hpp
+++ b/src/hotspot/share/runtime/vmOperation.hpp
@@ -38,6 +38,7 @@
   template(None)                                  \
   template(Cleanup)                               \
   template(ThreadDump)                            \
+  template(CoroutineDump)                         \
   template(PrintThreads)                          \
   template(FindDeadlocks)                         \
   template(ClearICs)                              \

--- a/src/hotspot/share/runtime/vmOperations.cpp
+++ b/src/hotspot/share/runtime/vmOperations.cpp
@@ -340,6 +340,33 @@ void VM_ThreadDump::snapshot_thread(JavaThread* java_thread, ThreadConcurrentLoc
   snapshot->set_concurrent_locks(tcl);
 }
 
+ThreadSnapshot* VM_CoroutineDump::snapshot_thread(JavaThread* java_thread, ThreadConcurrentLocks* tcl) {
+  ThreadSnapshot* snapshot = _result->add_thread_snapshot(java_thread);
+  snapshot->dump_stack_at_safepoint_for_coroutine(_target);
+  snapshot->set_concurrent_locks(tcl);
+  return snapshot;
+}
+
+VM_CoroutineDump::VM_CoroutineDump(ThreadDumpResult* result, Coroutine *target) {
+  assert(EnableCoroutine, "coroutine enabled");
+  _result = result;
+  _target = target;
+}
+
+bool VM_CoroutineDump::doit_prologue() {
+  assert(EnableCoroutine && Thread::current()->is_Java_thread(), "just checking");
+
+  return true;
+}
+
+void VM_CoroutineDump::doit_epilogue() {}
+
+void VM_CoroutineDump::doit() {
+  ResourceMark rm;
+
+  ThreadSnapshot* ts = snapshot_thread(_target->thread(), NULL);
+}
+
 volatile bool VM_Exit::_vm_exited = false;
 Thread * volatile VM_Exit::_shutdown_thread = NULL;
 

--- a/src/hotspot/share/runtime/vmOperations.hpp
+++ b/src/hotspot/share/runtime/vmOperations.hpp
@@ -241,6 +241,22 @@ class VM_ThreadDump : public VM_Operation {
 };
 
 
+class VM_CoroutineDump : public VM_Operation {
+ private:
+  ThreadDumpResult*              _result;
+  Coroutine *                    _target;
+
+  ThreadSnapshot* snapshot_thread(JavaThread* java_thread, ThreadConcurrentLocks* tcl);
+
+ public:
+  VM_CoroutineDump(ThreadDumpResult* result, Coroutine *target);
+
+  VMOp_Type type() const { return VMOp_CoroutineDump; }
+  void doit();
+  bool doit_prologue();
+  void doit_epilogue();
+};
+
 class VM_Exit: public VM_Operation {
  private:
   int  _exit_code;

--- a/src/hotspot/share/services/threadService.cpp
+++ b/src/hotspot/share/services/threadService.cpp
@@ -368,13 +368,15 @@ Handle ThreadService::dump_coroutine_stack_trace(Coroutine *coro, TRAPS) {
 
   assert(dump_result.num_snapshots() == 1, "must only one stacktrace");
   ThreadStackTrace* stacktrace = dump_result.snapshots()->get_stack_trace();
+  Handle stacktrace_h;
   if (stacktrace == NULL) {
     // No stack trace
-    return Handle();
+    stacktrace_h = Handle();
   } else {
     // Construct an array of java/lang/StackTraceElement object
-    return stacktrace->allocate_fill_stack_trace_element_array(CHECK_NH);
+    stacktrace_h = stacktrace->allocate_fill_stack_trace_element_array(CHECK_NH);
   }
+  return stacktrace_h;
 }
 
 void ThreadService::reset_contention_count_stat(JavaThread* thread) {

--- a/src/hotspot/share/services/threadService.cpp
+++ b/src/hotspot/share/services/threadService.cpp
@@ -353,6 +353,30 @@ Handle ThreadService::dump_stack_traces(GrowableArray<instanceHandle>* threads,
   return result_obj;
 }
 
+// Dump stack trace of Coroutine and return StackTraceElement[].
+Handle ThreadService::dump_coroutine_stack_trace(Coroutine *coro, TRAPS) {
+
+  assert(EnableCoroutine, "coroutine enabled");
+
+  ThreadDumpResult dump_result;
+  VM_CoroutineDump op(&dump_result, coro);
+  VMThread::execute(&op);
+
+  // Allocate the resulting StackTraceElement[] object
+
+  ResourceMark rm(THREAD);
+
+  assert(dump_result.num_snapshots() == 1, "must only one stacktrace");
+  ThreadStackTrace* stacktrace = dump_result.snapshots()->get_stack_trace();
+  if (stacktrace == NULL) {
+    // No stack trace
+    return Handle();
+  } else {
+    // Construct an array of java/lang/StackTraceElement object
+    return stacktrace->allocate_fill_stack_trace_element_array(CHECK_NH);
+  }
+}
+
 void ThreadService::reset_contention_count_stat(JavaThread* thread) {
   ThreadStatistics* stat = thread->get_thread_stat();
   if (stat != NULL) {
@@ -737,6 +761,41 @@ void ThreadStackTrace::add_stack_frame(javaVFrame* jvf) {
   _depth++;
 }
 
+void ThreadStackTrace::dump_stack_at_safepoint_for_coroutine(Coroutine *target) {
+  assert(SafepointSynchronize::is_at_safepoint(), "all threads are stopped");
+
+  Coroutine::CoroutineState state = target->state();
+  if (state != Coroutine::_onstack && state != Coroutine::_current) {
+    return;
+  }
+
+  RegisterMap reg_map(state == Coroutine::_onstack ? _thread : target->thread());
+  vframe* vf = NULL;
+  if (target->state() == Coroutine::_onstack) {
+    assert(_thread == target->thread(), "thread should equal");
+    frame last_frame = target->stack()->last_frame(target, reg_map);
+
+    JavaThread* t = UseWispMonitor ? target->wisp_thread() : _thread;
+    vf = vframe::new_vframe(&last_frame, &reg_map, t);
+  } else if (target->state() == Coroutine::_current) {
+    // we couldn't use the _current Coroutine to dump the stack of current Coroutine,
+    // while entering into safepoint, the sp/ip/fp will be stored to JavaThread::last_java_sp() etc.
+    // the _current Coroutine's sp/ip/fp are not updated.
+    JavaThread *t = target->thread();
+    if (t->has_last_Java_frame()) {
+      vf = t->last_java_vframe(&reg_map);
+    }
+  }
+
+  while (vf) {
+    if (vf->is_java_frame()) {
+      javaVFrame* jvf = javaVFrame::cast(vf);
+      add_stack_frame(jvf);
+    }
+    vf = vf->sender();
+  }
+}
+
 void ThreadStackTrace::metadata_do(void f(Metadata*)) {
   int length = _frames->length();
   for (int i = 0; i < length; i++) {
@@ -943,6 +1002,11 @@ ThreadSnapshot::~ThreadSnapshot() {
 void ThreadSnapshot::dump_stack_at_safepoint(int max_depth, bool with_locked_monitors) {
   _stack_trace = new ThreadStackTrace(_thread, with_locked_monitors);
   _stack_trace->dump_stack_at_safepoint(max_depth);
+}
+
+void ThreadSnapshot::dump_stack_at_safepoint_for_coroutine(Coroutine *target) {
+  _stack_trace = new ThreadStackTrace(_thread, false);
+  _stack_trace->dump_stack_at_safepoint_for_coroutine(target);
 }
 
 

--- a/src/hotspot/share/services/threadService.hpp
+++ b/src/hotspot/share/services/threadService.hpp
@@ -108,6 +108,8 @@ public:
   static Handle dump_stack_traces(GrowableArray<instanceHandle>* threads,
                                   int num_threads, TRAPS);
 
+  static Handle dump_coroutine_stack_trace(Coroutine *coro, TRAPS);
+
   static void   reset_peak_thread_count();
   static void   reset_contention_count_stat(JavaThread* thread);
   static void   reset_contention_time_stat(JavaThread* thread);
@@ -248,6 +250,7 @@ public:
   ThreadConcurrentLocks* get_concurrent_locks()     { return _concurrent_locks; }
 
   void        dump_stack_at_safepoint(int max_depth, bool with_locked_monitors);
+  void        dump_stack_at_safepoint_for_coroutine(Coroutine *target);
   void        set_concurrent_locks(ThreadConcurrentLocks* l) { _concurrent_locks = l; }
   void        metadata_do(void f(Metadata*));
 };
@@ -271,6 +274,7 @@ class ThreadStackTrace : public CHeapObj<mtInternal> {
 
   void            add_stack_frame(javaVFrame* jvf);
   void            dump_stack_at_safepoint(int max_depth);
+  void            dump_stack_at_safepoint_for_coroutine(Coroutine *target);
   Handle          allocate_fill_stack_trace_element_array(TRAPS);
   void            metadata_do(void f(Metadata*));
   GrowableArray<OopHandle>* jni_locked_monitors() { return _jni_locked_monitors; }

--- a/src/java.base/share/classes/com/alibaba/wisp/engine/WispTask.java
+++ b/src/java.base/share/classes/com/alibaba/wisp/engine/WispTask.java
@@ -572,6 +572,9 @@ public class WispTask implements Comparable<WispTask> {
         }
     }
 
+    public StackTraceElement[] getStackTrace() {
+        return this.ctx.getCoroutineStack();
+    }
 
     private static final AtomicIntegerFieldUpdater<WispTask> JVM_PARK_UPDATER;
     private static final AtomicIntegerFieldUpdater<WispTask> JDK_PARK_UPDATER;

--- a/src/java.base/share/classes/java/dyn/Coroutine.java
+++ b/src/java.base/share/classes/java/dyn/Coroutine.java
@@ -164,6 +164,14 @@ public class Coroutine extends CoroutineBase {
         setWispTask(nativeCoroutine, id, task, engine);
     }
 
+    /**
+     * get StackTrace element for coroutine
+     * @return StackTraceElement
+     */
+    public StackTraceElement[] getCoroutineStack() {
+        return CoroutineSupport.getCoroutineStack(nativeCoroutine);
+    }
+
     protected void run() {
         assert Thread.currentThread() == threadSupport.getThread();
         if (target != null) {

--- a/src/java.base/share/classes/java/dyn/CoroutineSupport.java
+++ b/src/java.base/share/classes/java/dyn/CoroutineSupport.java
@@ -394,4 +394,10 @@ public class CoroutineSupport {
      */
     public static native void setWispBooted();
 
+    /**
+     * this will turn on a safepoint to stop all threads.
+     * @param coroPtr coroutine
+     * @return target coroutine's stack
+     */
+    public static native StackTraceElement[] getCoroutineStack(long coroPtr);
 }

--- a/src/java.base/share/classes/java/lang/Thread.java
+++ b/src/java.base/share/classes/java/lang/Thread.java
@@ -1725,10 +1725,10 @@ public class Thread implements Runnable {
                 slowPath = this != Thread.currentThread();
             } else {
                 boolean isCurrentTask = WEA.getCurrentTask() == task;
-                if (!WEA.isThreadTask(task) && !isCurrentTask) {
-                    throw new UnsupportedOperationException("NYI, can NOT get other runnable Coroutine stacktrace!");
-                }
                 slowPath = !isCurrentTask;
+                if (!WEA.isThreadTask(task) && !isCurrentTask) {
+                    return task.getStackTrace();
+                }
             }
         } else {
             slowPath = this != Thread.currentThread();

--- a/test/hotspot/jtreg/runtime/coroutine/MemLeakTest.java
+++ b/test/hotspot/jtreg/runtime/coroutine/MemLeakTest.java
@@ -1,7 +1,7 @@
 /*
  * @test
  * @summary test of memory leak while creating and destroying coroutine/thread
- * @run main/othervm -XX:+EnableCoroutine  -Xmx10m  -Xms10m MemLeakTest
+ * @run main/othervm -XX:+EnableCoroutine -Dcom.alibaba.wisp.version=2  -Xmx10m  -Xms10m MemLeakTest
  */
 
 import java.dyn.Coroutine;


### PR DESCRIPTION
This patch consists 2 patches in dragonwell11, see details below.

Original dragonwell11 link:
https://github.com/dragonwell-project/dragonwell11/commit/8a1969c445580e1d863b32c44e38a51a56eaec8c
https://github.com/dragonwell-project/dragonwell11/commit/c04b9fe347dd3486c4aca4b6e32a89c790610c00

Reviewed-by: yulei

Issue:
https://github.com/dragonwell-project/dragonwell17/issues/92

---

[Wisp] Port jstack related changes to JDK11
Summary:
Port jstack related changes to JDK11:
[Wisp] jstack enhancement for Wisp
[Wisp] Some minor code adjustment for object monitor
[Wisp] Coroutine support of cross-thread stacktrace dumping

Test Plan: test/runtime/coroutine/JStackTest.java

---

[Wisp11] solve slowdebug issue for the previous checkin
Summary:
Solve the slowdebug issue for the previous checkin in dump_coroutine_stack_trace
Build error is as below:
In static member function 'static Handle
ThreadService::dump_coroutine_stack_trace(Coroutine*, Thread*)':
error: control reaches end of non-void function [-Werror=return-type]

The issue is related to the usage of CHECK_NH.

In JDK11 slowdebug build, the compiler check is stricter than JDK8.

Test Plan: build successfully with release and slowdebug

---