### PR TITLE
[Wisp] Solve port issue and fix crash.

### DIFF
--- a/make/data/hotspot-symbols/symbols-unix
+++ b/make/data/hotspot-symbols/symbols-unix
@@ -194,6 +194,7 @@ JVM_SetNativeThreadName
 JVM_SetPrimitiveArrayElement
 JVM_SetThreadPriority
 JVM_SetWispTask
+JVM_UpdateThreadObjectForWispThread
 JVM_Sleep
 JVM_StartThread
 JVM_StopThread

--- a/src/hotspot/cpu/aarch64/interp_masm_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/interp_masm_aarch64.cpp
@@ -852,7 +852,11 @@ void InterpreterMacroAssembler::unlock_object(Register lock_reg)
   assert(lock_reg == c_rarg1, "The argument is only for looks. It must be rarg1");
 
   if (UseHeavyMonitors) {
-    call_VM_leaf(CAST_FROM_FN_PTR(address, InterpreterRuntime::monitorexit), lock_reg);
+    if (UseWispMonitor) {
+      call_VM(noreg, CAST_FROM_FN_PTR(address, InterpreterRuntime::monitorexit_wisp), lock_reg);
+    } else {
+      call_VM_leaf(CAST_FROM_FN_PTR(address, InterpreterRuntime::monitorexit), lock_reg);
+    }
   } else {
     Label done;
 
@@ -888,7 +892,11 @@ void InterpreterMacroAssembler::unlock_object(Register lock_reg)
 
     // Call the runtime routine for slow case.
     str(obj_reg, Address(lock_reg, BasicObjectLock::obj_offset_in_bytes())); // restore obj
-    call_VM_leaf(CAST_FROM_FN_PTR(address, InterpreterRuntime::monitorexit), lock_reg);
+    if (UseWispMonitor) {
+      call_VM(noreg, CAST_FROM_FN_PTR(address, InterpreterRuntime::monitorexit_wisp), lock_reg);
+    } else {
+      call_VM_leaf(CAST_FROM_FN_PTR(address, InterpreterRuntime::monitorexit), lock_reg);
+    }
 
     bind(done);
 

--- a/src/hotspot/cpu/aarch64/sharedRuntime_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/sharedRuntime_aarch64.cpp
@@ -1909,7 +1909,7 @@ nmethod* SharedRuntime::generate_native_wrapper(MacroAssembler* masm,
   Label reguard;
   Label reguard_done;
   __ ldrb(rscratch1, Address(rthread, JavaThread::stack_guard_state_offset()));
-  __ cmpw(rscratch1, StackOverflow::stack_guard_yellow_reserved_disabled);
+  __ cmpw(rscratch1, static_cast<int>(StackOverflow::stack_guard_yellow_reserved_disabled));
   __ br(Assembler::EQ, reguard);
   __ bind(reguard_done);
 
@@ -2058,6 +2058,7 @@ nmethod* SharedRuntime::generate_native_wrapper(MacroAssembler* masm,
     __ ldr(r19, Address(rthread, in_bytes(Thread::pending_exception_offset())));
     __ str(zr, Address(rthread, in_bytes(Thread::pending_exception_offset())));
 
+    // TODO WispMonitor yield
     rt_call(masm, CAST_FROM_FN_PTR(address, SharedRuntime::complete_monitor_unlocking_C));
 
 #ifdef ASSERT
@@ -3298,7 +3299,7 @@ void NativeInvokerGenerator::generate() {
   Label L_reguard;
   Label L_after_reguard;
   __ ldrb(rscratch1, Address(rthread, JavaThread::stack_guard_state_offset()));
-  __ cmpw(rscratch1, StackOverflow::stack_guard_yellow_reserved_disabled);
+  __ cmpw(rscratch1, static_cast<int>(StackOverflow::stack_guard_yellow_reserved_disabled));
   __ br(Assembler::EQ, L_reguard);
   __ bind(L_after_reguard);
 

--- a/src/hotspot/cpu/arm/interp_masm_arm.cpp
+++ b/src/hotspot/cpu/arm/interp_masm_arm.cpp
@@ -990,7 +990,11 @@ void InterpreterMacroAssembler::unlock_object(Register Rlock) {
   assert(Rlock == R0, "the first argument");
 
   if (UseHeavyMonitors) {
-    call_VM_leaf(CAST_FROM_FN_PTR(address, InterpreterRuntime::monitorexit), Rlock);
+    if (UseWispMonitor) {
+      call_VM(noreg, CAST_FROM_FN_PTR(address, InterpreterRuntime::monitorexit_wisp), Rlock);
+    } else {
+      call_VM_leaf(CAST_FROM_FN_PTR(address, InterpreterRuntime::monitorexit), Rlock);
+    }
   } else {
     Label done, slow_case;
 
@@ -1030,7 +1034,11 @@ void InterpreterMacroAssembler::unlock_object(Register Rlock) {
 
     // Call the runtime routine for slow case.
     str(Robj, Address(Rlock, obj_offset)); // restore obj
-    call_VM_leaf(CAST_FROM_FN_PTR(address, InterpreterRuntime::monitorexit), Rlock);
+    if (UseWispMonitor) {
+      call_VM(noreg, CAST_FROM_FN_PTR(address, InterpreterRuntime::monitorexit_wisp), Rlock);
+    } else {
+      call_VM_leaf(CAST_FROM_FN_PTR(address, InterpreterRuntime::monitorexit), Rlock);
+    }
 
     bind(done);
   }

--- a/src/hotspot/cpu/arm/sharedRuntime_arm.cpp
+++ b/src/hotspot/cpu/arm/sharedRuntime_arm.cpp
@@ -1235,7 +1235,7 @@ nmethod* SharedRuntime::generate_native_wrapper(MacroAssembler* masm,
   __ ldr_s32(R2, Address(Rthread, JavaThread::stack_guard_state_offset()));
   __ str_32(Rtemp, Address(Rthread, JavaThread::thread_state_offset()));
 
-  __ cmp(R2, StackOverflow::stack_guard_yellow_reserved_disabled);
+  __ cmp(R2, static_cast<unsigned>(StackOverflow::stack_guard_yellow_reserved_disabled));
   __ b(reguard, eq);
   __ bind(reguard_done);
 

--- a/src/hotspot/cpu/arm/templateInterpreterGenerator_arm.cpp
+++ b/src/hotspot/cpu/arm/templateInterpreterGenerator_arm.cpp
@@ -962,9 +962,9 @@ address TemplateInterpreterGenerator::generate_native_entry(bool synchronized) {
   {
     __ ldr_u32(Rtemp, Address(Rthread, JavaThread::stack_guard_state_offset()));
     __ cmp_32(Rtemp, StackOverflow::stack_guard_yellow_reserved_disabled);
-  __ call(CAST_FROM_FN_PTR(address, SharedRuntime::reguard_yellow_pages), relocInfo::none, eq);
+    __ call(CAST_FROM_FN_PTR(address, SharedRuntime::reguard_yellow_pages), relocInfo::none, eq);
 #if R9_IS_SCRATCHED
-  __ restore_method();
+    __ restore_method();
 #endif
   }
 

--- a/src/hotspot/cpu/ppc/interp_masm_ppc_64.cpp
+++ b/src/hotspot/cpu/ppc/interp_masm_ppc_64.cpp
@@ -1022,7 +1022,11 @@ void InterpreterMacroAssembler::lock_object(Register monitor, Register object) {
 // Throw IllegalMonitorException if object is not locked by current thread.
 void InterpreterMacroAssembler::unlock_object(Register monitor) {
   if (UseHeavyMonitors) {
-    call_VM_leaf(CAST_FROM_FN_PTR(address, InterpreterRuntime::monitorexit), monitor);
+    if (UseWispMonitor) {
+      call_VM(noreg, CAST_FROM_FN_PTR(address, InterpreterRuntime::monitorexit_wisp), monitor);
+    } else {
+      call_VM_leaf(CAST_FROM_FN_PTR(address, InterpreterRuntime::monitorexit), monitor);
+    }
   } else {
 
     // template code:
@@ -1094,7 +1098,11 @@ void InterpreterMacroAssembler::unlock_object(Register monitor) {
     // The lock has been converted into a heavy lock and hence
     // we need to get into the slow case.
     bind(slow_case);
-    call_VM_leaf(CAST_FROM_FN_PTR(address, InterpreterRuntime::monitorexit), monitor);
+    if (UseWispMonitor) {
+      call_VM(noreg, CAST_FROM_FN_PTR(address, InterpreterRuntime::monitorexit_wisp), monitor);
+    } else {
+      call_VM_leaf(CAST_FROM_FN_PTR(address, InterpreterRuntime::monitorexit), monitor);
+    }
     // }
 
     Label done;

--- a/src/hotspot/cpu/ppc/sharedRuntime_ppc.cpp
+++ b/src/hotspot/cpu/ppc/sharedRuntime_ppc.cpp
@@ -2362,7 +2362,7 @@ nmethod *SharedRuntime::generate_native_wrapper(MacroAssembler *masm,
 
   Label no_reguard;
   __ lwz(r_temp_1, thread_(stack_guard_state));
-  __ cmpwi(CCR0, r_temp_1, StackOverflow::stack_guard_yellow_reserved_disabled);
+  __ cmpwi(CCR0, r_temp_1, static_cast<int>(StackOverflow::stack_guard_yellow_reserved_disabled));
   __ bne(CCR0, no_reguard);
 
   save_native_result(masm, ret_type, workspace_slot_offset);

--- a/src/hotspot/cpu/s390/interp_masm_s390.cpp
+++ b/src/hotspot/cpu/s390/interp_masm_s390.cpp
@@ -1077,7 +1077,11 @@ void InterpreterMacroAssembler::lock_object(Register monitor, Register object) {
 void InterpreterMacroAssembler::unlock_object(Register monitor, Register object) {
 
   if (UseHeavyMonitors) {
-    call_VM_leaf(CAST_FROM_FN_PTR(address, InterpreterRuntime::monitorexit), monitor);
+    if (UseWispMonitor) {
+      call_VM(noreg, CAST_FROM_FN_PTR(address, InterpreterRuntime::monitorexit_wisp), monitor);
+    } else {
+      call_VM_leaf(CAST_FROM_FN_PTR(address, InterpreterRuntime::monitorexit), monitor);
+    }
     return;
   }
 
@@ -1151,7 +1155,11 @@ void InterpreterMacroAssembler::unlock_object(Register monitor, Register object)
   // The lock has been converted into a heavy lock and hence
   // we need to get into the slow case.
   z_stg(object, obj_entry);   // Restore object entry, has been cleared above.
-  call_VM_leaf(CAST_FROM_FN_PTR(address, InterpreterRuntime::monitorexit), monitor);
+  if (UseWispMonitor) {
+    call_VM(noreg, CAST_FROM_FN_PTR(address, InterpreterRuntime::monitorexit_wisp), monitor);
+  } else {
+    call_VM_leaf(CAST_FROM_FN_PTR(address, InterpreterRuntime::monitorexit), monitor);
+  }
 
   // }
 

--- a/src/hotspot/cpu/s390/sharedRuntime_s390.cpp
+++ b/src/hotspot/cpu/s390/sharedRuntime_s390.cpp
@@ -2056,7 +2056,7 @@ nmethod *SharedRuntime::generate_native_wrapper(MacroAssembler *masm,
   Label no_reguard;
 
   __ z_cli(Address(Z_thread, JavaThread::stack_guard_state_offset() + in_ByteSize(sizeof(StackOverflow::StackGuardState) - 1)),
-           StackOverflow::stack_guard_yellow_reserved_disabled);
+           static_cast<int64_t>(StackOverflow::stack_guard_yellow_reserved_disabled));
 
   __ z_bre(no_reguard);
 

--- a/src/hotspot/cpu/x86/sharedRuntime_x86_32.cpp
+++ b/src/hotspot/cpu/x86/sharedRuntime_x86_32.cpp
@@ -2138,13 +2138,17 @@ nmethod* SharedRuntime::generate_native_wrapper(MacroAssembler* masm,
     // should be a peal
     // +wordSize because of the push above
     // args are (oop obj, BasicLock* lock, JavaThread* thread)
-    __ push(thread);
     __ lea(rax, Address(rbp, lock_slot_rbp_offset));
-    __ push(rax);
+    if (UseWispMonitor) {
+      __ call_VM(noreg, CAST_FROM_FN_PTR(address, SharedRuntime::complete_wisp_monitor_unlocking_C), obj_reg, rax);
+    } else {
+      __ push(thread);
+      __ push(rax);
+      __ push(obj_reg);
+      __ call(RuntimeAddress(CAST_FROM_FN_PTR(address, SharedRuntime::complete_monitor_unlocking_C)));
+      __ addptr(rsp, 3*wordSize);
+    }
 
-    __ push(obj_reg);
-    __ call(RuntimeAddress(CAST_FROM_FN_PTR(address, SharedRuntime::complete_monitor_unlocking_C)));
-    __ addptr(rsp, 3*wordSize);
 #ifdef ASSERT
     {
       Label L;

--- a/src/hotspot/cpu/x86/templateInterpreterGenerator_x86.cpp
+++ b/src/hotspot/cpu/x86/templateInterpreterGenerator_x86.cpp
@@ -1141,7 +1141,7 @@ address TemplateInterpreterGenerator::generate_native_entry(bool synchronized) {
   {
     Label no_reguard;
     __ cmpl(Address(thread, JavaThread::stack_guard_state_offset()),
-            StackOverflow::stack_guard_yellow_reserved_disabled);
+            static_cast<int32_t>(StackOverflow::stack_guard_yellow_reserved_disabled));
     __ jcc(Assembler::notEqual, no_reguard);
 
     __ pusha(); // XXX only save smashed registers

--- a/src/hotspot/cpu/zero/zeroInterpreter_zero.cpp
+++ b/src/hotspot/cpu/zero/zeroInterpreter_zero.cpp
@@ -483,7 +483,12 @@ int ZeroInterpreter::native_entry(Method* method, intptr_t UNUSED, TRAPS) {
       markWord old_header = markWord::encode(lock);
       if (rcvr->cas_set_mark(header, old_header) != old_header) {
         monitor->set_obj(rcvr);
-        InterpreterRuntime::monitorexit(monitor);
+        if (UseWispMonitor) {
+          HandleMark hm(thread);
+          CALL_VM_NOCHECK(InterpreterRuntime::monitorexit_wisp(thread, monitor));
+        } else {
+          InterpreterRuntime::monitorexit(monitor);
+        }
       }
     }
   }

--- a/src/hotspot/share/c1/c1_Runtime1.cpp
+++ b/src/hotspot/share/c1/c1_Runtime1.cpp
@@ -753,12 +753,7 @@ JRT_LEAF(void, Runtime1::monitorexit(JavaThread* current, BasicObjectLock* lock)
   assert(current->last_Java_sp(), "last_Java_sp must be set");
   oop obj = lock->obj();
   assert(oopDesc::is_oop(obj), "must be NULL or an object");
-  if (UseWispMonitor) {
-    HandleMarkCleaner __hm(current);
-    SharedRuntime::monitor_exit_helper(obj, lock->lock(), current);
-  } else {
-    SharedRuntime::monitor_exit_helper(obj, lock->lock(), current);
-  }
+  SharedRuntime::monitor_exit_helper<oopDesc*>(obj, lock->lock(), current);
 JRT_END
 
 // Cf. OptoRuntime::deoptimize_caller_frame

--- a/src/hotspot/share/include/jvm.h
+++ b/src/hotspot/share/include/jvm.h
@@ -1052,6 +1052,9 @@ JVM_IsSameClassPackage(JNIEnv *env, jclass class1, jclass class2);
 JNIEXPORT void JNICALL
 JVM_SetWispTask(JNIEnv* env, jclass clz, jlong coroutinePtr, jint task_id, jobject task, jobject engine);
 
+JNIEXPORT void JNICALL
+JVM_UpdateThreadObjectForWispThread(JNIEnv* env, jclass clz, jlong coroutinePtr, jobject threadObject);
+
 JNIEXPORT jint JNICALL
 JVM_GetProxyUnpark(JNIEnv* env, jclass clz, jintArray res);
 

--- a/src/hotspot/share/interpreter/interpreterRuntime.hpp
+++ b/src/hotspot/share/interpreter/interpreterRuntime.hpp
@@ -112,6 +112,7 @@ class InterpreterRuntime: AllStatic {
   // Synchronization
   static void    monitorenter(JavaThread* current, BasicObjectLock* elem);
   static void    monitorexit (BasicObjectLock* elem);
+  static void    monitorexit_wisp(JavaThread* current, BasicObjectLock* elem);
 
   static void    throw_illegal_monitor_state_exception(JavaThread* current);
   static void    new_illegal_monitor_state_exception(JavaThread* current);

--- a/src/hotspot/share/jvmci/jvmciRuntime.cpp
+++ b/src/hotspot/share/jvmci/jvmciRuntime.cpp
@@ -399,7 +399,14 @@ JRT_END
 JRT_LEAF(void, JVMCIRuntime::monitorexit(JavaThread* current, oopDesc* obj, BasicLock* lock))
   assert(current->last_Java_sp(), "last_Java_sp must be set");
   assert(oopDesc::is_oop(obj), "invalid lock object pointer dected");
-  SharedRuntime::monitor_exit_helper(obj, lock, current);
+  SharedRuntime::monitor_exit_helper<oopDesc*>(obj, lock, current);
+JRT_END
+
+JRT_ENTRY_NO_ASYNC(void, JVMCIRuntime::monitorexit_wisp(JavaThread* current, oopDesc* obj, BasicLock* lock))
+  assert(current->last_Java_sp(), "last_Java_sp must be set");
+  assert(oopDesc::is_oop(obj), "invalid lock object pointer dected");
+  Handle h_obj(current, obj);
+  SharedRuntime::monitor_exit_helper<Handle>(h_obj, lock, current);
 JRT_END
 
 // Object.notify() fast path, caller does slow path

--- a/src/hotspot/share/jvmci/jvmciRuntime.hpp
+++ b/src/hotspot/share/jvmci/jvmciRuntime.hpp
@@ -388,6 +388,7 @@ class JVMCIRuntime: public CHeapObj<mtJVMCI> {
   static address exception_handler_for_pc(JavaThread* current);
   static void monitorenter(JavaThread* current, oopDesc* obj, BasicLock* lock);
   static void monitorexit (JavaThread* current, oopDesc* obj, BasicLock* lock);
+  static void monitorexit_wisp (JavaThread* current, oopDesc* obj, BasicLock* lock);
   static jboolean object_notify(JavaThread* current, oopDesc* obj);
   static jboolean object_notifyAll(JavaThread* current, oopDesc* obj);
   static void vm_error(JavaThread* current, jlong where, jlong format, jlong value);

--- a/src/hotspot/share/opto/macro.cpp
+++ b/src/hotspot/share/opto/macro.cpp
@@ -2432,9 +2432,8 @@ void PhaseMacroExpand::expand_unlock_node(UnlockNode *unlock) {
   Node *thread = transform_later(new ThreadLocalNode());
 
   CallNode *call;
-  if (UseWispMonitor &&
-      ((CallNode *)unlock->jvms() != NULL) && ((CallNode *)unlock->jvms()->has_method())) {
-    call = make_slow_call( (CallNode *) unlock, OptoRuntime::complete_monitor_exit_Type(), OptoRuntime::complete_wisp_monitor_unlocking_Java(), NULL, slow_path, obj, box, thread);
+  if (UseWispMonitor && ((CallNode *)unlock->jvms() != NULL) && ((CallNode *)unlock->jvms()->has_method())) {
+    call = make_slow_call( (CallNode *) unlock, OptoRuntime::complete_monitor_exit_Type(), OptoRuntime::complete_wisp_monitor_unlocking_Java(), NULL, slow_path, thread, obj, box);
   } else {
     call = make_slow_call( (CallNode *) unlock, OptoRuntime::complete_monitor_exit_Type(), CAST_FROM_FN_PTR(address, SharedRuntime::complete_monitor_unlocking_C), "complete_monitor_unlocking_C", slow_path, obj, box, thread);
   }

--- a/src/hotspot/share/opto/runtime.hpp
+++ b/src/hotspot/share/opto/runtime.hpp
@@ -174,7 +174,7 @@ public:
   // Slow-path Locking and Unlocking
   static void complete_monitor_locking_C(oopDesc* obj, BasicLock* lock, JavaThread* thread);
   static void complete_monitor_unlocking_C(oopDesc* obj, BasicLock* lock, JavaThread* thread);
-  static void complete_wisp_monitor_unlocking_C(oopDesc* obj, BasicLock* lock, JavaThread* thread);
+  static void complete_wisp_monitor_unlocking_C(JavaThread* thread, oopDesc* obj, BasicLock* lock);
 
   static void monitor_notify_C(oopDesc* obj, JavaThread* current);
   static void monitor_notifyAll_C(oopDesc* obj, JavaThread* current);

--- a/src/hotspot/share/prims/jvm.cpp
+++ b/src/hotspot/share/prims/jvm.cpp
@@ -3878,6 +3878,16 @@ JVM_ENTRY(void, JVM_SetWispTask(JNIEnv* env, jclass klass, jlong coroutinePtr, j
   coro->set_wisp_task(JNIHandles::resolve_non_null(task));
 JVM_END
 
+JVM_ENTRY(void, JVM_UpdateThreadObjectForWispThread(JNIEnv* env, jclass klass, jlong coroutinePtr, jobject threadObject))
+  assert(EnableCoroutine, "Coroutine is disabled");
+  if (UseWispMonitor) {
+    Coroutine* coro = (Coroutine*)coroutinePtr;
+    WispThread* wt = coro->wisp_thread();
+    assert(wt != NULL, "Sanity check");
+    wt->set_threadObj(JNIHandles::resolve(threadObject));
+  }
+JVM_END
+
 JVM_ENTRY(jint, JVM_GetProxyUnpark(JNIEnv* env, jclass klass, jintArray res))
   assert(EnableCoroutine, "Coroutine is disabled");
   return WispThread::get_proxy_unpark(res);

--- a/src/hotspot/share/prims/unsafe.cpp
+++ b/src/hotspot/share/prims/unsafe.cpp
@@ -1019,6 +1019,16 @@ JVM_ENTRY (void, CoroutineSupport_checkAndThrowException0(JNIEnv* env, jclass kl
   }
 JVM_END
 
+JVM_ENTRY (void, CoroutineSupport_printlnLockFree(JNIEnv* env, jclass klass, jstring info))
+  assert(EnableCoroutine, "pre-condition");
+  ResourceMark rm(THREAD);
+
+  Handle h_info (THREAD, JNIHandles::resolve_non_null(info));
+  char* str = java_lang_String::as_utf8_string(h_info());
+  fprintf(stdout, "%s\n", str);
+  fflush(stdout);
+JVM_END
+
 JVM_ENTRY (jobjectArray, CoroutineSupport_getCoroutineStack(JNIEnv* env, jclass klass, jlong coroPtr))
   assert(EnableCoroutine, "pre-condition");
 
@@ -1132,6 +1142,7 @@ JNINativeMethod coroutine_support_methods[] = {
     {CC"markThreadCoroutine",     CC "(J" COBA ")V",     FN_PTR(CoroutineSupport_markThreadCoroutine)},
     {CC"getCoroutineStack",       CC "(J)[" STE,         FN_PTR(CoroutineSupport_getCoroutineStack)},
     {CC"checkAndThrowException0", CC "(J)V",             FN_PTR(CoroutineSupport_checkAndThrowException0)},
+    {CC"printlnLockFree",         CC "(" LANG "String;)V", FN_PTR(CoroutineSupport_printlnLockFree)},
 };
 
 #define COMPILE_CORO_METHODS_BEFORE (3)

--- a/src/hotspot/share/runtime/coroutine.cpp
+++ b/src/hotspot/share/runtime/coroutine.cpp
@@ -272,6 +272,7 @@ bool Coroutine::is_coroutine_frame(vframe* f) {
   Preempt should only happened when we're executing the non-wisp part.
 */
 bool Coroutine::in_critical(JavaThread* thread) {
+  ResourceMark resMark;
   RegisterMap reg_map(thread);
   bool has_wisp_frame = false;
   bool has_other_frame = false;

--- a/src/hotspot/share/runtime/coroutine.hpp
+++ b/src/hotspot/share/runtime/coroutine.hpp
@@ -211,7 +211,7 @@ public:
 
   bool is_disposable();
 
-  oop print_stack_header_on(outputStream* st);
+  void print_stack_header_on(outputStream* st);
   void print_stack_on(outputStream* st);
 
   bool is_coroutine_frame(vframe* f);
@@ -264,10 +264,10 @@ private:
   ReservedSpace   _reserved_space;
   VirtualSpace    _virtual_space;
 
-  address         _stack_base;
+  StackOverflow   _stack_overflow_state;
   intptr_t        _stack_size;
-  bool            _default_size;
 
+  bool            _default_size;
   address         _last_sp;
 
   // objects of this type can only be created via static functions
@@ -283,11 +283,12 @@ public:
 
   JavaThread* thread() const                { return _thread; }
   bool is_thread_stack() const              { return _is_thread_stack; }
+  StackOverflow* stack_overflow_state()     { return &_stack_overflow_state; }
 
   address last_sp() const                   { return _last_sp; }
   void set_last_sp(address x)               { _last_sp = x; }
 
-  address stack_base() const                { return _stack_base; }
+  address stack_base() const                { return _stack_overflow_state.stack_base(); }
   intptr_t stack_size() const               { return _stack_size; }
   bool is_default_size() const              { return _default_size; }
 
@@ -296,7 +297,22 @@ public:
   // GC support
   void frames_do(FrameClosure* fc);
 
-  static ByteSize stack_base_offset()         { return byte_offset_of(CoroutineStack, _stack_base); }
+  static ByteSize stack_base_offset()  {
+    return byte_offset_of(CoroutineStack, _stack_overflow_state._stack_base);
+  }
+  static ByteSize stack_end_offset() {
+    return byte_offset_of(CoroutineStack, _stack_overflow_state._stack_end);
+  }
+  static ByteSize stack_guard_state_offset() {
+    return byte_offset_of(CoroutineStack, _stack_overflow_state._stack_guard_state);
+  }
+  static ByteSize stack_overflow_limit_offset() {
+    return byte_offset_of(CoroutineStack, _stack_overflow_state._stack_overflow_limit);
+  }
+  static ByteSize reserved_stack_activation_offset() {
+    return byte_offset_of(CoroutineStack, _stack_overflow_state._reserved_stack_activation);
+  }
+
   static ByteSize stack_size_offset()         { return byte_offset_of(CoroutineStack, _stack_size); }
   static ByteSize last_sp_offset()            { return byte_offset_of(CoroutineStack, _last_sp); }
 };

--- a/src/hotspot/share/runtime/objectMonitor.cpp
+++ b/src/hotspot/share/runtime/objectMonitor.cpp
@@ -1462,10 +1462,10 @@ bool ObjectMonitor::reenter(intx recursions, JavaThread* current) {
 // (IMSE). If there is a pending exception and the specified thread
 // is not the owner, that exception will be replaced by the IMSE.
 bool ObjectMonitor::check_owner(TRAPS) {
-  JavaThread* current = THREAD;
   if (UseWispMonitor) {
-    current = WispThread::current(current);
+    THREAD = WispThread::current(THREAD);
   }
+  JavaThread* current = THREAD;
   void* cur = owner_raw();
   if (cur == current) {
     return true;
@@ -1524,10 +1524,10 @@ static bool check_interrupt(Thread* current, bool clear_interrupted) {
 // Note: a subset of changes to ObjectMonitor::wait()
 // will need to be replicated in complete_exit
 void ObjectMonitor::wait(jlong millis, bool interruptible, TRAPS) {
-  JavaThread* current = THREAD;
   if (UseWispMonitor) {
-    current = WispThread::current(current);
+    THREAD = WispThread::current(THREAD);
   }
+  JavaThread* current = THREAD;
 
   assert(InitDone, "Unexpectedly not initialized");
 
@@ -1828,10 +1828,10 @@ void ObjectMonitor::INotify(JavaThread* current) {
 // that suggests a lost wakeup bug.
 
 void ObjectMonitor::notify(TRAPS) {
-  JavaThread* current = THREAD;
   if (UseWispMonitor) {
-    current = WispThread::current(current);
+    THREAD = WispThread::current(THREAD);
   }
+  JavaThread* current = THREAD;
   CHECK_OWNER();  // Throws IMSE if not owner.
   if (_WaitSet == NULL) {
     return;
@@ -1850,10 +1850,10 @@ void ObjectMonitor::notify(TRAPS) {
 // mode the waitset will be empty and the EntryList will be "DCBAXYZ".
 
 void ObjectMonitor::notifyAll(TRAPS) {
-  JavaThread* current = THREAD;
   if (UseWispMonitor) {
-    current = WispThread::current(current);
+    THREAD = WispThread::current(THREAD);
   }
+  JavaThread* current = THREAD;
   CHECK_OWNER();  // Throws IMSE if not owner.
   if (_WaitSet == NULL) {
     return;

--- a/src/hotspot/share/runtime/sharedRuntime.hpp
+++ b/src/hotspot/share/runtime/sharedRuntime.hpp
@@ -344,7 +344,8 @@ class SharedRuntime: AllStatic {
 
   static void monitor_enter_helper(oopDesc* obj, BasicLock* lock, JavaThread* thread);
 
-  static void monitor_exit_helper(oopDesc* obj, BasicLock* lock, JavaThread* current);
+  template<typename OopRef>
+  static void monitor_exit_helper(OopRef obj, BasicLock* lock, JavaThread* current);
 
  private:
   static Handle find_callee_info(Bytecodes::Code& bc, CallInfo& callinfo, TRAPS);
@@ -496,7 +497,7 @@ class SharedRuntime: AllStatic {
   // Slow-path Locking and Unlocking
   static void complete_monitor_locking_C(oopDesc* obj, BasicLock* lock, JavaThread* current);
   static void complete_monitor_unlocking_C(oopDesc* obj, BasicLock* lock, JavaThread* current);
-  static void complete_wisp_monitor_unlocking_C(oopDesc* obj, BasicLock* lock, JavaThread* current);
+  static void complete_wisp_monitor_unlocking_C(JavaThread* current, oopDesc* obj, BasicLock* lock);
 
   // Resolving of calls
   static address resolve_static_call_C     (JavaThread* current);

--- a/src/hotspot/share/runtime/thread.cpp
+++ b/src/hotspot/share/runtime/thread.cpp
@@ -832,7 +832,11 @@ oop  JavaThread::threadObj() const    {
 
 void JavaThread::set_threadObj(oop p) {
   assert(_thread_oop_storage != NULL, "not yet initialized");
-  _threadObj = OopHandle(_thread_oop_storage, p);
+  if (UseWispMonitor && NULL == p) {
+    _threadObj = OopHandle();
+  } else {
+    _threadObj = OopHandle(_thread_oop_storage, p);
+  }
 }
 
 OopStorage* JavaThread::thread_oop_storage() {
@@ -1084,6 +1088,7 @@ JavaThread::JavaThread() :
   _jvmci_reserved_oop0(nullptr),
 #endif // INCLUDE_JVMCI
 
+  _stack_overflow_state(),
   _exception_oop(oop()),
   _exception_pc(0),
   _exception_handler_pc(0),
@@ -2784,6 +2789,15 @@ void Threads::initialize_java_lang_classes(JavaThread* main_thread, TRAPS) {
     create_vm_init_libraries();
   }
 
+#ifdef ASSERT
+  InstanceKlass *k = vmClasses::UnsafeConstants_klass();
+  assert(k->is_not_initialized(), "UnsafeConstants should not already be initialized");
+#endif
+
+  // initialize the hardware-specific constants needed by Unsafe
+  initialize_class(vmSymbols::jdk_internal_misc_UnsafeConstants(), CHECK);
+  jdk_internal_misc_UnsafeConstants::set_unsafe_constants();
+
   initialize_class(vmSymbols::java_lang_String(), CHECK);
 
   // Inject CompactStrings value after the static initializers for String ran.
@@ -2801,15 +2815,6 @@ void Threads::initialize_java_lang_classes(JavaThread* main_thread, TRAPS) {
 
   // The VM creates objects of this class.
   initialize_class(vmSymbols::java_lang_Module(), CHECK);
-
-#ifdef ASSERT
-  InstanceKlass *k = vmClasses::UnsafeConstants_klass();
-  assert(k->is_not_initialized(), "UnsafeConstants should not already be initialized");
-#endif
-
-  // initialize the hardware-specific constants needed by Unsafe
-  initialize_class(vmSymbols::jdk_internal_misc_UnsafeConstants(), CHECK);
-  jdk_internal_misc_UnsafeConstants::set_unsafe_constants();
 
   // The VM preresolves methods to these classes. Make sure that they get initialized
   initialize_class(vmSymbols::java_lang_reflect_Method(), CHECK);

--- a/src/hotspot/share/runtime/thread.hpp
+++ b/src/hotspot/share/runtime/thread.hpp
@@ -1338,14 +1338,20 @@ class JavaThread: public Thread {
   static ByteSize is_method_handle_return_offset() { return byte_offset_of(JavaThread, _is_method_handle_return); }
 
   // StackOverflow offsets
-  static ByteSize stack_overflow_limit_offset()  {
+  static ByteSize stack_overflow_limit_offset()      {
     return byte_offset_of(JavaThread, _stack_overflow_state._stack_overflow_limit);
   }
-  static ByteSize stack_guard_state_offset()     {
+  static ByteSize stack_guard_state_offset()         {
     return byte_offset_of(JavaThread, _stack_overflow_state._stack_guard_state);
   }
   static ByteSize reserved_stack_activation_offset() {
     return byte_offset_of(JavaThread, _stack_overflow_state._reserved_stack_activation);
+  }
+  static ByteSize stack_base_offset()                {
+    return byte_offset_of(JavaThread, _stack_overflow_state._stack_base);
+  }
+  static ByteSize stack_end_offset()                 {
+    return byte_offset_of(JavaThread, _stack_overflow_state._stack_end);
   }
 
   static ByteSize suspend_flags_offset()         { return byte_offset_of(JavaThread, _suspend_flags); }

--- a/src/hotspot/share/runtime/thread.inline.hpp
+++ b/src/hotspot/share/runtime/thread.inline.hpp
@@ -206,7 +206,6 @@ inline void JavaThread::set_terminated(TerminatedTypes t) {
 inline void JavaThread::set_class_to_be_initialized(InstanceKlass* k) {
   assert((k == NULL && _class_to_be_initialized != NULL) ||
          (k != NULL && _class_to_be_initialized == NULL), "incorrect usage");
-  assert(this == Thread::current(), "Only the current thread can set this field");
   _class_to_be_initialized = k;
 }
 

--- a/src/hotspot/share/runtime/vframe.cpp
+++ b/src/hotspot/share/runtime/vframe.cpp
@@ -218,7 +218,11 @@ void javaVFrame::print_lock_info_on(outputStream* st, int frame_count) {
     else if (thread()->osthread()->get_state() == OBJECT_WAIT) {
       // We are waiting on an Object monitor but Object.wait() isn't the
       // top-frame, so we should be waiting on a Class initialization monitor.
-      InstanceKlass* k = thread()->class_to_be_initialized();
+      JavaThread* jt = thread();
+      if (UseWispMonitor) {
+        jt = WispThread::current(jt);
+      }
+      InstanceKlass* k = jt->class_to_be_initialized();
       if (k != NULL) {
         st->print_cr("\t- waiting on the Class initialization monitor for %s", k->external_name());
       }

--- a/src/hotspot/share/utilities/exceptions.cpp
+++ b/src/hotspot/share/utilities/exceptions.cpp
@@ -182,9 +182,6 @@ void Exceptions::_throw(JavaThread* thread, const char* file, int line, Handle h
 
 void Exceptions::_throw_msg(JavaThread* thread, const char* file, int line, Symbol* name, const char* message,
                             Handle h_loader, Handle h_protection_domain) {
-  if (UseWispMonitor && thread->is_Wisp_thread()) {
-    thread = ((WispThread*) thread)->thread();
-  }
   // Check for special boot-strapping/compiler-thread handling
   if (special_exception(thread, file, line, name, message)) return;
   // Create and throw exception
@@ -228,6 +225,9 @@ void Exceptions::_throw_msg_cause(JavaThread* thread, const char* file, int line
   _throw_msg_cause(thread, file, line, name, message, h_cause, Handle(thread, NULL), Handle(thread, NULL));
 }
 void Exceptions::_throw_msg(JavaThread* thread, const char* file, int line, Symbol* name, const char* message) {
+  if (UseWispMonitor && thread->is_Wisp_thread()) {
+    thread = ((WispThread*) thread)->thread();
+  }
   _throw_msg(thread, file, line, name, message, Handle(thread, NULL), Handle(thread, NULL));
 }
 void Exceptions::_throw_cause(JavaThread* thread, const char* file, int line, Symbol* name, Handle h_cause) {

--- a/src/java.base/linux/classes/sun/nio/ch/EPollSelectorImpl.java
+++ b/src/java.base/linux/classes/sun/nio/ch/EPollSelectorImpl.java
@@ -216,7 +216,7 @@ class EPollSelectorImpl extends SelectorImpl {
             }
         }
 
-        if (interrupted || WEA.useDirectSelectorWakeup() && status.get() == INTERRUPTED) {
+        if (interrupted || WispEngine.transparentWispSwitch() && WEA.useDirectSelectorWakeup() && status.get() == INTERRUPTED) {
             clearInterrupt();
         }
 
@@ -266,7 +266,7 @@ class EPollSelectorImpl extends SelectorImpl {
     public Selector wakeup() {
         synchronized (interruptLock) {
             if (!interruptTriggered) {
-                if (WEA.useDirectSelectorWakeup()) {
+                if (WispEngine.transparentWispSwitch() && WEA.useDirectSelectorWakeup()) {
                     WEA.interruptEpoll(status, INTERRUPTED, eventfd.efd());
                 } else {
                     try {
@@ -283,7 +283,7 @@ class EPollSelectorImpl extends SelectorImpl {
 
     private void clearInterrupt() throws IOException {
         synchronized (interruptLock) {
-            if (WEA.useDirectSelectorWakeup()) {
+            if (WispEngine.transparentWispSwitch() && WEA.useDirectSelectorWakeup()) {
                 assert status.get() == INTERRUPTED;
                 status.lazySet(null);
                 if (!WEA.isAllThreadAsWisp()) {

--- a/src/java.base/share/classes/java/dyn/Coroutine.java
+++ b/src/java.base/share/classes/java/dyn/Coroutine.java
@@ -165,6 +165,24 @@ public class Coroutine extends CoroutineBase {
     }
 
     /**
+     * Update thread object for coroutine WispThread.
+     * For transparent wisp mode, thread object is created by WispTask.
+     * It is should be updated to WispThread if UseMonitorWisp is open.
+     * Otherwise, Coroutine::print_stack_on could not print lock info.
+     * For each coroutine, it holds three thead objects: one is for underly
+     * JavaThread, one is for WispTask, one is for WispThread. The underly
+     * JavaThread threadObject should not be exposed to end user. Its status
+     * is not critical for user semantic. The WispTask and WispThread
+     * thread object should be same and reflect coroutine running/park status.
+     * Their thread object is created by WispTask and updated to WispThread.
+     *
+     * @param threadObject thread object oop or null.
+     */
+    public void updateThreadObjectForWispThread(Object threadObject) {
+        updateThreadObjectForWispThread(nativeCoroutine, threadObject);
+    }
+
+    /**
      * get StackTrace element for coroutine
      * @return StackTraceElement
      */
@@ -186,4 +204,6 @@ public class Coroutine extends CoroutineBase {
     private static native void registerNatives();
 
     private static native void setWispTask(long coroutine, int id, Object task, Object engine);
+
+    private static native void updateThreadObjectForWispThread(long coroutine, Object threadObject);
 }

--- a/src/java.base/share/classes/java/dyn/CoroutineSupport.java
+++ b/src/java.base/share/classes/java/dyn/CoroutineSupport.java
@@ -400,6 +400,12 @@ public class CoroutineSupport {
      */
     private static native void markThreadCoroutine(long coroPtr, CoroutineBase threadCoroutine);
 
+    /**
+     * print info by native method, without synchronize
+     * @param info info to be printed in Java
+     */
+    public static native void printlnLockFree(String info);
+
     @IntrinsicCandidate
 	private static native void switchTo(CoroutineBase current, CoroutineBase target);
 

--- a/src/java.base/share/native/libjava/Coroutine.c
+++ b/src/java.base/share/native/libjava/Coroutine.c
@@ -9,6 +9,7 @@
 
 static JNINativeMethod methods[] = {
   {"setWispTask","(JI"OBJ OBJ")V", (void *)&JVM_SetWispTask},
+  {"updateThreadObjectForWispThread","(J"OBJ")V", (void *)&JVM_UpdateThreadObjectForWispThread},
 };
 
 JNIEXPORT void JNICALL


### PR DESCRIPTION
This patch contains 2 patches in dragonwell11 plus a fix bugs patch written by us, see details below.

Original dragonwell11 link:
https://github.com/dragonwell-project/dragonwell11/commit/b5fa773a073a9832e785a4076e22abf00bf14c60
https://github.com/dragonwell-project/dragonwell11/commit/8ceb987e609f2f62dd1c2d7b80f7142c9ff8ecc3

Reviewed-by: yulei

Issue:
https://github.com/dragonwell-project/dragonwell17/issues/103

---

[Wisp] solve port issue from JDK8
Summary:
Due to some code diff between JDK8 and JDK11, there is an issue:
WEA using in EPollSelectorImpl.java
Before we initialize EPollSelectorImpl, we need to initialize
WispEngine. But this assumption does not hold true in JDK11.

Solution: remove WispEngineAccess dependency in nio when wisp
is disabled.

Test Plan:
cases under java/nio/channels/ and java/net/httpclient
jdk/java/net/httpclient/DigestEchoClient.java
jdk/java/net/httpclient/DigestEchoClientSSL.java
jdk/java/net/httpclient/ProxyAuthDisabledSchemesSSL.java
jdk/java/nio/channels/Selector/LotsOfUpdatesTest.java

---

[Wisp] solve crash with TestPreemptWispInternalBug in slowdebug
Summary:
Coroutine::in_critical calls JavaThread::last_java_vframe which will create a new vframe.
So we need to add "ResourceMark resMark".

Test Plan: com/alibaba/wisp2/bug/TestPreemptWispInternalBug.java

---