### PR TITLE
[Wisp] Port 8.8.13fp patches from JDK8.

### DIFF
--- a/src/hotspot/share/prims/unsafe.cpp
+++ b/src/hotspot/share/prims/unsafe.cpp
@@ -1015,6 +1015,7 @@ JVM_ENTRY (void, CoroutineSupport_checkAndThrowException0(JNIEnv* env, jclass kl
   Coroutine* coro = (Coroutine*)coroPtr;
   assert(coro == thread->current_coroutine(), "invariant");
   if (!coro->is_yielding() && coro->clinit_call_count() == 0) {
+    ThreadToNativeFromVM ttnfv(thread);
     throw_new(env, "java/lang/ThreadDeath");
   }
 JVM_END

--- a/src/hotspot/share/runtime/coroutine.cpp
+++ b/src/hotspot/share/runtime/coroutine.cpp
@@ -237,14 +237,10 @@ void Coroutine::frames_do(FrameClosure* fc) {
 }
 
 bool Coroutine::is_coroutine_frame(vframe* f) {
+  ResourceMark resMark;
   javaVFrame* jvf = javaVFrame::cast(f);
-  InstanceKlass* k = jvf->method()->method_holder();
-  return (k == vmClasses::com_alibaba_wisp_engine_WispTask_klass()
-    || k == vmClasses::com_alibaba_wisp_engine_WispEngine_klass()
-    || k->is_subtype_of(vmClasses::com_alibaba_wisp_engine_WispEngine_klass())
-    || k == vmClasses::com_alibaba_wisp_engine_WispEventPump_klass()
-    || k == vmClasses::com_alibaba_wisp_engine_WispTask_CacheableCoroutine_klass()
-    || k == vmClasses::java_dyn_CoroutineBase_klass());
+  const char* k_name = jvf->method()->method_holder()->name()->as_C_string();
+  return strstr(k_name, "com/alibaba/wisp/engine/") != 0 || strstr(k_name, "java/dyn/") != 0;
 }
 
 /* a typical wisp stack looks like:

--- a/src/java.base/linux/classes/sun/nio/ch/EPollSelectorProvider.java
+++ b/src/java.base/linux/classes/sun/nio/ch/EPollSelectorProvider.java
@@ -38,7 +38,7 @@ public class EPollSelectorProvider
 {
     public AbstractSelector openSelector() throws IOException {
         AbstractSelector sel = new EPollSelectorImpl(this);
-        if (WispEngine.transparentWispSwitch() &&
+        if (WispEngine.enableThreadAsWisp() &&
                 SharedSecrets.getWispEngineAccess().ifSpinSelector()) {
             sel = new SleepSelector(sel);
         }

--- a/src/java.base/share/classes/com/alibaba/wisp/engine/Wisp2Group.java
+++ b/src/java.base/share/classes/com/alibaba/wisp/engine/Wisp2Group.java
@@ -27,7 +27,7 @@ public class Wisp2Group extends AbstractExecutorService {
 
     final Wisp2Scheduler scheduler;
     final Set<Wisp2Engine> carrierEngines;
-    final Queue<WispTask> groupTaskCache = new ConcurrentLinkedDeque<>();
+    final Queue<WispTask> groupTaskCache = new ConcurrentLinkedQueue<>();
     final CyclicBarrier shutdownBarrier;
 
     /**

--- a/src/java.base/share/classes/com/alibaba/wisp/engine/WispEngine.java
+++ b/src/java.base/share/classes/com/alibaba/wisp/engine/WispEngine.java
@@ -721,7 +721,9 @@ public abstract class WispEngine extends AbstractExecutorService {
 
         unregisterEvent();
         returnTaskToCache(current);
-
+        // reset threadWrapper after call returnTaskToCache,
+        // since the threadWrapper will be used in Thread.currentThread()
+        current.resetThreadWrapper();
         counter.incrementCompleteTaskCount();
 
         if (runningTaskCount == 0 && threadTask.isRunnable()) {

--- a/src/java.base/share/classes/com/alibaba/wisp/engine/WispTask.java
+++ b/src/java.base/share/classes/com/alibaba/wisp/engine/WispTask.java
@@ -234,7 +234,6 @@ public class WispTask implements Comparable<WispTask> {
                         WispEngine.JLA.setWispAlive(threadWrapper, false);
                         if (isThreadAsWisp) {
                             ThreadAsWisp.exit(threadWrapper);
-                            setThreadWrapper(null); // else WispThreadWrapper could be reused
                         }
                         if (throwable instanceof CoroutineExitException) {
                             throw (CoroutineExitException) throwable;
@@ -514,6 +513,12 @@ public class WispTask implements Comparable<WispTask> {
         }
         if (ctx != null) {
             ctx.updateThreadObjectForWispThread(threadWrapper);
+        }
+    }
+
+    void resetThreadWrapper() {
+        if (isThreadAsWisp) {
+            setThreadWrapper(null);
         }
     }
 

--- a/src/java.base/share/classes/java/dyn/Coroutine.java
+++ b/src/java.base/share/classes/java/dyn/Coroutine.java
@@ -66,6 +66,28 @@ import jdk.internal.access.SharedSecrets;
  * @author Lukas Stadler
  */
 public class Coroutine extends CoroutineBase {
+    /**
+     * the result for steal
+     */
+    public enum StealResult {
+        /**
+         * steal successfully
+         */
+        SUCCESS,
+        /**
+         * steal failed due to lock failure
+         */
+        FAIL_BY_CONTENTION,
+        /**
+         * steal failed since the steal is forbiden with the status
+         */
+        FAIL_BY_STATUS,
+        /**
+         * steal failed since native frame isn't supported
+         */
+        FAIL_BY_NATIVE_FRAME
+    }
+
     private final Runnable target;
 
     /**
@@ -140,9 +162,10 @@ public class Coroutine extends CoroutineBase {
      * Steal a coroutine from it's carrier thread to current thread.
      *
      * @param failOnContention steal fail if there's too much lock contention
-     * @return if stealing succeeds. Also return true directly if coroutine's carrier thread is current.
+     *
+     * @return result described by Coroutine.STEAL_*. Also return SUCCESS directly if coroutine's carrier thread is current.
      */
-    public boolean steal(boolean failOnContention) {
+    public StealResult steal(boolean failOnContention) {
         return threadSupport.steal(this, failOnContention);
     }
 

--- a/src/java.base/share/classes/java/dyn/CoroutineSupport.java
+++ b/src/java.base/share/classes/java/dyn/CoroutineSupport.java
@@ -243,36 +243,39 @@ public class CoroutineSupport {
      * Steal coroutine from it's carrier thread to current thread.
      *
      * @param failOnContention steal fail if there's too much lock contention
-     * @param coroutine        to be stolen
+     *
+     * @param coroutine to be stolen
      */
-    boolean steal(Coroutine coroutine, boolean failOnContention) {
+    Coroutine.StealResult steal(Coroutine coroutine, boolean failOnContention) {
         assert coroutine.threadSupport.threadCoroutine() != coroutine;
         CoroutineSupport source = this;
         CoroutineSupport target = SharedSecrets.getJavaLangAccess().currentThread0().getCoroutineSupport();
 
         if (source == target) {
-            return true;
+            return Coroutine.StealResult.SUCCESS;
         }
 
         if (source.id < target.id) { // prevent dead lock
             if (!source.lockInternal(failOnContention)) {
-                return false;
+                return Coroutine.StealResult.FAIL_BY_CONTENTION;
             }
             target.lock();
         } else {
             target.lock();
             if (!source.lockInternal(failOnContention)) {
                 target.unlock();
-                return false;
+                return Coroutine.StealResult.FAIL_BY_CONTENTION;
             }
         }
 
         try {
             if (source.terminated || coroutine.finished ||
                     coroutine.threadSupport != source || // already been stolen
-                    source.currentCoroutine == coroutine || // running
-                    !stealCoroutine(coroutine.nativeCoroutine)) { // native frame
-                return false;
+                    source.currentCoroutine == coroutine) {
+                return Coroutine.StealResult.FAIL_BY_STATUS;
+            }
+            if (!stealCoroutine(coroutine.nativeCoroutine)) { // native frame
+                return Coroutine.StealResult.FAIL_BY_NATIVE_FRAME;
             }
             coroutine.threadSupport = target;
         } finally {
@@ -280,7 +283,7 @@ public class CoroutineSupport {
             target.unlock();
         }
 
-        return true;
+        return Coroutine.StealResult.SUCCESS;
     }
 
     /**

--- a/test/jdk/com/alibaba/wisp/monitor/TestPassToken.java
+++ b/test/jdk/com/alibaba/wisp/monitor/TestPassToken.java
@@ -4,7 +4,6 @@
  * @summary Test object lock with coroutine
  * @modules java.base/jdk.internal.access
  * @modules java.base/com.alibaba.wisp.engine:+open
- * @run main/othervm  -XX:-UseBiasedLocking -XX:+EnableCoroutine -XX:+UseWispMonitor -Dcom.alibaba.wisp.transparentWispSwitch=true TestPassToken
  * @run main/othervm  -XX:-UseBiasedLocking -XX:+EnableCoroutine -XX:+UseWispMonitor -Dcom.alibaba.wisp.transparentWispSwitch=true -Dcom.alibaba.wisp.version=2 -Dcom.alibaba.wisp.schedule.policy=PULL TestPassToken
  * @run main/othervm  -XX:-UseBiasedLocking -XX:+EnableCoroutine -XX:+UseWispMonitor -Dcom.alibaba.wisp.transparentWispSwitch=true -Dcom.alibaba.wisp.version=2 -Dcom.alibaba.wisp.schedule.policy=PUSH TestPassToken
  * @run main/othervm  -XX:-UseBiasedLocking -XX:+EnableCoroutine -XX:+UseWispMonitor -Dcom.alibaba.wisp.transparentWispSwitch=true -Dcom.alibaba.wisp.version=2 -DcheckStealEnable=true TestPassToken

--- a/test/jdk/com/alibaba/wisp/monitor/TestPassToken.java
+++ b/test/jdk/com/alibaba/wisp/monitor/TestPassToken.java
@@ -1,0 +1,178 @@
+/*
+ * @test
+ * @library /test/lib
+ * @summary Test object lock with coroutine
+ * @modules java.base/jdk.internal.access
+ * @modules java.base/com.alibaba.wisp.engine:+open
+ * @run main/othervm  -XX:-UseBiasedLocking -XX:+EnableCoroutine -XX:+UseWispMonitor -Dcom.alibaba.wisp.transparentWispSwitch=true TestPassToken
+ * @run main/othervm  -XX:-UseBiasedLocking -XX:+EnableCoroutine -XX:+UseWispMonitor -Dcom.alibaba.wisp.transparentWispSwitch=true -Dcom.alibaba.wisp.version=2 -Dcom.alibaba.wisp.schedule.policy=PULL TestPassToken
+ * @run main/othervm  -XX:-UseBiasedLocking -XX:+EnableCoroutine -XX:+UseWispMonitor -Dcom.alibaba.wisp.transparentWispSwitch=true -Dcom.alibaba.wisp.version=2 -Dcom.alibaba.wisp.schedule.policy=PUSH TestPassToken
+ * @run main/othervm  -XX:-UseBiasedLocking -XX:+EnableCoroutine -XX:+UseWispMonitor -Dcom.alibaba.wisp.transparentWispSwitch=true -Dcom.alibaba.wisp.version=2 -DcheckStealEnable=true TestPassToken
+
+ */
+
+
+import com.alibaba.wisp.engine.WispEngine;
+import com.alibaba.wisp.engine.WispTask;
+import jdk.internal.access.SharedSecrets;
+
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.locks.Condition;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+
+import static jdk.test.lib.Asserts.assertTrue;
+
+public class TestPassToken {
+    private final static boolean needCheckStealEnable = Boolean.getBoolean("checkStealEnable");
+    final static Runner[] runners = new Runner[8];
+    static boolean JUC;
+    static final int N = 40000;
+
+    public static void main(String[] args) throws Exception {
+        JUC = true;
+        System.out.println("JUC");
+        doTest();
+        JUC = false;
+        System.out.println("ObjectMonitor");
+        doTest();
+    }
+
+    private static void doTest() {
+        for (int i = 0; i < runners.length; i++) {
+            runners[i] = new Runner(i);
+        }
+        List<Runnable> plans = new ArrayList<>(Arrays.asList(
+                () -> { // only coroutine
+                    for (Runner runner1 : runners) {
+                        WispEngine.dispatch(runner1);
+                    }
+                },
+                () -> { // only thread
+                    int n = 0;
+                    for (Runner runner : runners) {
+                        new Thread(runner, "MP-THREAD-RUNNER-" + n++).start();
+                    }
+                },
+                () -> { //mixed
+                    int n = 0;
+                    for (int i = 0; i < runners.length; i += 2) {
+                        final int ci = i;
+                        new Thread(() -> {
+                            for (int j = ci; j < ci + 2 && j < runners.length; j++) {
+                                WispEngine.dispatch(runners[j]);
+                            }
+                        }, "MP-MIX-RUNNER-" + n++).start();
+                    }
+                }));
+        Collections.shuffle(plans);
+
+        plans.forEach(plan -> {
+            finishLatch = new CountDownLatch(runners.length);
+            current = 0;
+            long start = System.currentTimeMillis();
+            plan.run(); // create runners
+            try {
+                finishLatch.await();
+            } catch (InterruptedException e) {
+                e.printStackTrace();
+            }
+            System.out.println("elapsed = " + (System.currentTimeMillis() - start) + "ms");
+        });
+
+        System.out.println("-----------");
+    }
+
+
+    static int current = 0;
+    static final Lock lock = new ReentrantLock();
+    static final Condition cond = lock.newCondition();
+    static CountDownLatch finishLatch;
+
+    static class Runner implements Runnable {
+
+        private final int ord;
+
+        public Runner(int ord) {
+            this.ord = ord;
+        }
+
+        @Override
+        public void run() {
+            WispTask task = SharedSecrets.getWispEngineAccess().getCurrentTask();
+
+            while (current < N) {
+                if (JUC) {
+                    lock.lock();
+                    try {
+                        while (current % runners.length != ord) {
+                            try {
+                                cond.await();
+                                checkStealEnable(task);
+                            } catch (InterruptedException e) {
+                                e.printStackTrace();
+                            }
+                        }
+                        if (++current % 10000 == 0) // pass the token
+                            System.out.println(SharedSecrets.getJavaLangAccess().currentThread0().getName() + "\t" + current);
+                    } finally {
+                        lock.unlock();
+                    }
+                } else {
+                    synchronized (lock) {
+                        while (current % runners.length != ord) {
+                            try {
+                                lock.wait();
+                                checkStealEnable(task);
+                            } catch (InterruptedException e) {
+                                e.printStackTrace();
+                            }
+                        }
+                        if (++current % 10000 == 0) // pass the token
+                            System.out.println(SharedSecrets.getJavaLangAccess().currentThread0().getName() + "\t" + current);
+                    }
+                }
+
+                if (JUC) {
+                    lock.lock();
+                    try {
+                        cond.signalAll();
+                    } finally {
+                        lock.unlock();
+                    }
+                } else {
+                    synchronized (lock) {
+                        lock.notifyAll();
+                    }
+                }
+            }
+
+            finishLatch.countDown();
+        }
+
+        static void checkStealEnable(WispTask task) {
+            if (!needCheckStealEnable) {
+                return;
+            }
+            try {
+                Field resumeEntryField = task.getClass().getDeclaredField("resumeEntry");
+                resumeEntryField.setAccessible(true);
+                final Object resumeEntry = resumeEntryField.get(task);
+                if (resumeEntry == null) {
+                    return;
+                }
+                Field stealEnableField = resumeEntry.getClass().getDeclaredField("stealEnable");
+                stealEnableField.setAccessible(true);
+                assertTrue(stealEnableField.getBoolean(resumeEntry));
+            } catch (ReflectiveOperationException e) {
+                throw new Error(e);
+            }
+        }
+    }
+}
+

--- a/test/jdk/com/alibaba/wisp/thread/TestThreadAsWisp.java
+++ b/test/jdk/com/alibaba/wisp/thread/TestThreadAsWisp.java
@@ -4,8 +4,8 @@
  * @modules java.base/jdk.internal.access
  * @modules java.base/com.alibaba.wisp.engine:+open
  * @library /test/lib
- * @run main/othervm -XX:+EnableCoroutine -XX:+UseWispMonitor -Dcom.alibaba.wisp.transparentWispSwitch=true -Dcom.alibaba.threadPoolLimit=true -Dcom.alibaba.wisp.enableThreadAsWisp=true ThreadAsWispTest
- * @run main/othervm -XX:+EnableCoroutine -XX:+UseWispMonitor -Dcom.alibaba.wisp.transparentWispSwitch=true -Dcom.alibaba.threadPoolLimit=true -Dcom.alibaba.wisp.enableThreadAsWisp=true -Dcom.alibaba.wisp.version=2 -XX:ActiveProcessorCount=4 ThreadAsWispTest
+ * @run main/othervm -XX:+EnableCoroutine -XX:+UseWispMonitor -Dcom.alibaba.wisp.transparentWispSwitch=true -Dcom.alibaba.threadPoolLimit=true -Dcom.alibaba.wisp.enableThreadAsWisp=true TestThreadAsWisp
+ * @run main/othervm -XX:+EnableCoroutine -XX:+UseWispMonitor -Dcom.alibaba.wisp.transparentWispSwitch=true -Dcom.alibaba.threadPoolLimit=true -Dcom.alibaba.wisp.enableThreadAsWisp=true -Dcom.alibaba.wisp.version=2 -XX:ActiveProcessorCount=4 TestThreadAsWisp
 */
 
 
@@ -33,7 +33,7 @@ import java.util.stream.IntStream;
 import static jdk.test.lib.Asserts.assertEQ;
 import static jdk.test.lib.Asserts.assertTrue;
 
-public class ThreadAsWispTest {
+public class TestThreadAsWisp {
     static Thread mainThread;
 
     private static Lock lock = new ReentrantLock();
@@ -74,9 +74,9 @@ public class ThreadAsWispTest {
         System.setProperty("com.alibaba.wisp.config", f.getAbsolutePath());
         f.deleteOnExit();
         FileWriter writer = new FileWriter(f);
-        writer.write("com.alibaba.wisp.biz.manage=ThreadAsWispTest::main\n");
-        writer.write("com.alibaba.wisp.biz.current=ThreadAsWispTest::main\n");
-        writer.write("com.alibaba.wisp.biz.black=ThreadAsWispTest::shouldNotShift\n");
+        writer.write("com.alibaba.wisp.biz.manage=TestThreadAsWisp::main\n");
+        writer.write("com.alibaba.wisp.biz.current=TestThreadAsWisp::main\n");
+        writer.write("com.alibaba.wisp.biz.black=TestThreadAsWisp::shouldNotShift\n");
 
         writer.close();
 

--- a/test/jdk/com/alibaba/wisp2/TestAdjustCarrier.java
+++ b/test/jdk/com/alibaba/wisp2/TestAdjustCarrier.java
@@ -3,9 +3,10 @@
  * @library /test/lib
  * @summary test for adjusting carrier number at runtime
  * @modules java.base/com.alibaba.wisp.engine:+open
- * @run main/othervm -XX:+UseWisp2 -Dcom.alibaba.wisp.growCarrierTickUs=200000  TestAjustCarrier
+ * @run main/othervm -XX:+UseWisp2 -Dcom.alibaba.wisp.growCarrierTickUs=200000  TestAdjustCarrier
  */
 
+import com.alibaba.wisp.engine.Wisp2Group;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
@@ -16,64 +17,44 @@ import java.util.concurrent.ThreadFactory;
 
 import static jdk.test.lib.Asserts.assertTrue;
 
-public class TestAjustCarrier {
+public class TestAdjustCarrier {
 	public static void main(String[] args) throws Exception{
 		Thread.currentThread().setName("Wisp-Sysmon");
 		Class<?> claz = Class.forName("com.alibaba.wisp.engine.Wisp2Scheduler");
-		Method method =  claz.getDeclaredMethod("checkAndGrowCarriers", int.class);
+		Method method = claz.getDeclaredMethod("checkAndGrowCarriers", int.class);
 		method.setAccessible(true);
-		Constructor<?> c = Class.forName("com.alibaba.wisp.engine.Wisp2Group")
-				.getDeclaredConstructor(int.class, ThreadFactory.class);
-		c.setAccessible(true);
-		ExecutorService g = (ExecutorService) c.newInstance(4, new ThreadFactory() {
-			@Override
-			public Thread newThread(Runnable r) {
-				return new Thread(r);
-			}
-		});
+        ExecutorService g = Wisp2Group.createGroup(4, Thread::new);
 
 		CountDownLatch latch = new CountDownLatch(100);
 		CountDownLatch grow = new CountDownLatch(1);
 
-		for (int i = 0; i < 50; i++) {
-			g.execute(new Runnable() {
-				@Override
-				public void run() {
-					try {
-						grow.await();
-						latch.countDown();
-					} catch (Exception e) {
-						e.printStackTrace();
-					}
-				}
-			});
-		}
+        for (int i = 0; i < 50; i++) {
+            g.execute(() -> {
+                try {
+                    grow.await();
+                    latch.countDown();
+                } catch (Exception e) {
+                    e.printStackTrace();
+                }
+            });
+        }
 
 		Field scheduler = Class.forName("com.alibaba.wisp.engine.Wisp2Group").getDeclaredField("scheduler");
 		scheduler.setAccessible(true);
 		method.invoke(scheduler.get(g), 100);
 		grow.countDown();
 
-
-		for (int i = 0; i < 50; i++) {
-			g.execute(new Runnable() {
-				@Override
-				public void run() {
-					latch.countDown();
-				}
-			});
-		}
+        for (int i = 0; i < 50; i++) {
+            g.execute(latch::countDown);
+        }
 
 		latch.await();
 		Field f = claz.getDeclaredField("carriers");
 		f.setAccessible(true);
 		System.out.println(f.get(scheduler.get(g)).getClass().toString());
-		assertTrue(((Object[])(f.get(scheduler.get(g)))).length == 100);
+		assertTrue(((Object[]) (f.get(scheduler.get(g)))).length == 100);
 		Field name = Class.forName("com.alibaba.wisp.engine.WispSysmon").getDeclaredField("WISP_SYSMON_NAME");
 		name.setAccessible(true);
 		assertTrue(name.get(null).equals("Wisp-Sysmon"));
 	}
-
-
-
 }

--- a/test/jdk/com/alibaba/wisp2/TestWisp2WithGlobalCache.java
+++ b/test/jdk/com/alibaba/wisp2/TestWisp2WithGlobalCache.java
@@ -1,0 +1,81 @@
+/*
+ * @test
+ * @library /test/lib
+ * @summary test the task exit flow for ThreadAsWisp task
+ * @modules java.base/jdk.internal.access
+ * @run main/othervm -XX:ActiveProcessorCount=2 -XX:+EnableCoroutine  -Dcom.alibaba.wisp.transparentWispSwitch=true  -Dcom.alibaba.wisp.version=2 -XX:+UseWispMonitor -Dcom.alibaba.wisp.enableThreadAsWisp=true -Dcom.alibaba.wisp.allThreadAsWisp=true -Dcom.alibaba.wisp.engineTaskCache=2 TestWisp2WithGlobalCache
+ */
+
+import jdk.internal.access.SharedSecrets;
+
+import java.util.Timer;
+import java.util.TimerTask;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+import static jdk.test.lib.Asserts.assertTrue;
+
+public class TestWisp2WithGlobalCache {
+    public static void main(String[] args) throws Exception {
+        CountDownLatch done = new CountDownLatch(80);
+
+        Runnable r = () -> {
+            try {
+                Thread.sleep(100);
+            } catch(Throwable t) {
+            }
+            if (SharedSecrets.getJavaLangAccess().currentThread0() != Thread.currentThread()) {
+                done.countDown();
+            }
+        };
+
+        for (int i = 0; i < 10; i++) {
+            new Thread(r).start();
+            new Timer().schedule(new TimerTask() {
+                @Override
+                public void run() {
+                    r.run();
+                }
+            }, 0);
+            new Thread() {
+                @Override
+                public void run() {
+                    r.run();
+                }
+            }.start();
+            new Thread() {
+                @Override
+                public void run() {
+                    r.run();
+                }
+            }.start();
+            new Thread() {
+                @Override
+                public void run() {
+                    r.run();
+                }
+            }.start();
+            new Thread() {
+                @Override
+                public void run() {
+                    r.run();
+                }
+            }.start();
+            new Thread() {
+                @Override
+                public void run() {
+                    r.run();
+                }
+            }.start();
+            new Thread() {
+                @Override
+                public void run() {
+                    r.run();
+                }
+            }.start();
+        }
+
+        assertTrue(done.await(10, TimeUnit.SECONDS));
+    }
+}

--- a/test/jdk/com/alibaba/wisp2/bug/TestPreemptWisp2InternalBug.java
+++ b/test/jdk/com/alibaba/wisp2/bug/TestPreemptWisp2InternalBug.java
@@ -24,7 +24,7 @@ public class TestPreemptWisp2InternalBug {
 	        for (int i = 0; i < tasks.length; i++) {
 		        ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(
 				        "-XX:+UseWisp2", "-XX:+UnlockDiagnosticVMOptions", "-XX:+VerboseWisp", "-XX:-Inline",
-                        "--add-exports=java.base/jdk.internal.misc=ALL-UNNAMED",
+                        "--add-exports=java.base/jdk.internal.access=ALL-UNNAMED",
 				        TestPreemptWisp2InternalBug.class.getName(), tasks[i]);
 		        OutputAnalyzer output = new OutputAnalyzer(pb.start());
 		        output.shouldContain("[WISP] preempt was blocked, because wisp internal method on the stack");

--- a/test/jdk/com/alibaba/wisp2/bug/TestPreemptWisp2InternalBug.java
+++ b/test/jdk/com/alibaba/wisp2/bug/TestPreemptWisp2InternalBug.java
@@ -1,0 +1,75 @@
+/*
+ * @test
+ * @summary Verify wisp internal logic can not be preempted
+ * @library /test/lib
+ * @modules java.base/jdk.internal.access
+ * @run main TestPreemptWisp2InternalBug
+ */
+
+import com.alibaba.wisp.engine.Wisp2Group;
+import com.alibaba.wisp.engine.WispEngine;
+import jdk.internal.access.SharedSecrets;
+
+import java.util.HashMap;
+import java.util.concurrent.FutureTask;
+import jdk.test.lib.process.ProcessTools;
+import jdk.test.lib.process.OutputAnalyzer;
+
+
+public class TestPreemptWisp2InternalBug {
+	private static String[] tasks = new String[] {"toString", "addTimer"};
+
+    public static void main(String[] args) throws Exception {
+        if (args.length == 0) {
+	        for (int i = 0; i < tasks.length; i++) {
+		        ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(
+				        "-XX:+UseWisp2", "-XX:+UnlockDiagnosticVMOptions", "-XX:+VerboseWisp", "-XX:-Inline",
+                        "--add-exports=java.base/jdk.internal.misc=ALL-UNNAMED",
+				        TestPreemptWisp2InternalBug.class.getName(), tasks[i]);
+		        OutputAnalyzer output = new OutputAnalyzer(pb.start());
+		        output.shouldContain("[WISP] preempt was blocked, because wisp internal method on the stack");
+	        }
+            return;
+        }
+
+        FutureTask future = getTask(args[0]);
+        WispEngine.dispatch(future);
+        future.get();
+    }
+
+	private static FutureTask toStringTask() {
+		return new FutureTask<>(() -> {
+			long start = System.currentTimeMillis();
+			Object task = SharedSecrets.getWispEngineAccess().getCurrentTask();
+			while (System.currentTimeMillis() - start < 1000) {
+				for (int i = 0; i < 100; i++) {
+                    task.toString();
+				}
+			}
+			return null;
+		});
+	}
+
+	private static FutureTask addTimerTask() {
+		return new FutureTask<>(() -> {
+			long start = System.currentTimeMillis();
+			while (System.currentTimeMillis() - start < 2000) {
+				for (int i = 0; i < 100; i++) {
+					SharedSecrets.getWispEngineAccess().addTimer(System.nanoTime() + 1008611);
+				}
+			}
+			return null;
+		});
+	}
+
+	private static FutureTask getTask(String taskName) {
+        switch (taskName) {
+	            case "toString":
+		        return toStringTask();
+                    case "addTimer":
+		        return addTimerTask();
+	            default:
+		        throw new IllegalArgumentException();
+	    }
+	}
+}

--- a/test/jdk/java/dyn/TestBasicSteal.java
+++ b/test/jdk/java/dyn/TestBasicSteal.java
@@ -2,7 +2,7 @@
  * @test
  * @summary test basic coroutine steal mechanism
  * @library /test/lib
- * @run main/othervm -XX:+EnableCoroutine BasicStealTest
+ * @run main/othervm -XX:+EnableCoroutine TestBasicSteal
  */
 
 import java.dyn.Coroutine;
@@ -12,7 +12,7 @@ import java.util.function.Consumer;
 import static jdk.test.lib.Asserts.assertEQ;
 import static jdk.test.lib.Asserts.assertTrue;
 
-public class BasicStealTest {
+public class TestBasicSteal {
     public static void main(String[] args) {
         AtomicReference<Coroutine> toBeStolen = new AtomicReference<>();
         Thread main = Thread.currentThread();
@@ -50,7 +50,7 @@ public class BasicStealTest {
         while (toBeStolen.get() == null) {
         }
 
-        assertTrue(toBeStolen.get().steal(false));
+        assertEQ(toBeStolen.get().steal(false), Coroutine.StealResult.SUCCESS);
         Coroutine.yieldTo(toBeStolen.get());
 
     }

--- a/test/jdk/java/dyn/TestConcurrentSteal.java
+++ b/test/jdk/java/dyn/TestConcurrentSteal.java
@@ -1,6 +1,6 @@
 /* @test
  * @summary unit tests for steal in concurrent situation
- * @run junit/othervm/timeout=300 -XX:+EnableCoroutine ConcurrentStealTest
+ * @run junit/othervm/timeout=300 -XX:+EnableCoroutine TestConcurrentSteal
  */
 
 import org.junit.Test;
@@ -15,7 +15,7 @@ import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
 
 import static org.junit.Assert.*;
 
-public class ConcurrentStealTest {
+public class TestConcurrentSteal {
 
     @Test
     public void stealRunning() throws Exception {
@@ -41,12 +41,12 @@ public class ConcurrentStealTest {
 
         Thread.sleep(500);
 
-        assertFalse(coro[0].steal(true));
+        assertEquals(coro[0].steal(false), Coroutine.StealResult.FAIL_BY_STATUS);
     }
 
     final static int THREADS = Math.min(Runtime.getRuntime().availableProcessors(), 8);
     final static int CORO_PER_TH = 20;
-    final static int TIMEOUT = 10000;
+    final static int TIMEOUT = 10;
 
     @Test
     public void randomSteal() throws Exception {
@@ -144,7 +144,7 @@ public class ConcurrentStealTest {
                         cnt[cth].yieldCnt++;
                     } else {
                         CoroutineAdaptor target = workers[nxt].stealables.pollFirst();
-                        if (target != null && target.steal(true)) {
+                        if (target != null && target.steal(true) == Coroutine.StealResult.SUCCESS) {
                             stealables.add(target);
                             cnt[cth].stealCnt++;
                         } else {

--- a/test/jdk/java/dyn/TestCoroutine.java
+++ b/test/jdk/java/dyn/TestCoroutine.java
@@ -25,7 +25,7 @@
 
 /* @test
  * @summary unit tests for coroutines
- * @run junit/othervm -XX:+EnableCoroutine test.java.dyn.CoroutineTest
+ * @run junit/othervm -XX:+EnableCoroutine test.java.dyn.TestCoroutine
  */
 
 package test.java.dyn;
@@ -39,7 +39,7 @@ import static org.junit.Assert.*;
 import org.junit.Before;
 import org.junit.Test;
 
-public class CoroutineTest {
+public class TestCoroutine {
 	private StringBuilder seq;
 
 	@Before


### PR DESCRIPTION
This patch is the main patch(Port 8.8.13fp patches from JDK8.) along with some fix to solve crash.

Original dragonwell11 link:
https://github.com/dragonwell-project/dragonwell11/commit/d86f2f88c4f7d800b83952dd3c54a4adac46c181
https://github.com/dragonwell-project/dragonwell11/commit/2e80f5ddeb7a61e64a212627d9fcbdaabfded4bf
https://github.com/dragonwell-project/dragonwell11/commit/09fafe11d0f7aaa0deca50fd4e0bdd7fa960fd60

Reviewed-by: yulei

Issue:
https://github.com/dragonwell-project/dragonwell17/issues/105

---

[Wisp] Port 8.8.13fp patches from JDK8

Summary:
The change is to port 8.8.13fp patches including:
-[Wisp] Fix preempt wisp internal in wisp2
https://code.aone.alibaba-inc.com/xcode/jdk8u_hotspot/codereview/1957520
-[Wisp2] Fix test hang occasionally caused by D1955616
https://code.aone.alibaba-inc.com/xcode/jdk8u_jdk/codereview/1958239
-[Wisp] Modify running time in ConcurrentStealTest
https://code.aone.alibaba-inc.com/xcode/jdk8u_jdk/codereview/1934679
-[Wisp2] enabling steal for contention fail
https://code.aone.alibaba-inc.com/xcode/jdk8u_jdk/codereview/1955616
-[Wisp] make SleepSelector controlled by enableThreadAsWisp
https://code.aone.alibaba-inc.com/xcode/jdk8u_jdk/codereview/1936913

Test Plan:
com/alibaba/wisp/monitor/TestPassToken.java
com/alibaba/wisp2/bug/TestPreemptWisp2InternalBug.java

---

[Wisp] solve crash for the exit with ThreadAsWisp Task
Summary:
For threadAsWisp task:
when the task exits, the threadWrapper is set to null.
Then Thread.currentThread() returns null.

Any operation which uses Thread.currentThread() will cause NPE
or crash.

To solve the issue:
1. avoid class loading during task exit
2. delay that the threadWrapper is set to null

Test Plan: test/jdk/com/alibaba/wisp2/TestWisp2WithGlobalCache.java

---

[Wisp] ObjectMonitor::wait() checks wrong _pending_exception
Summary:
1. HAS_PENDING_EXCEPTION uses THREAD, but it has been changed to the WispThread.
2. fix TestWisp2Shutdown.java failure on slowdebug
3. fix TestKillThreadWithWisp.java failure on release

Test Plan: Fastdebug ver. jvm to test spectjbb2015

---