### PR TITLE
[Backport] 8272873: C2: Inlining should not depend on absolute call site counts

### DIFF
--- a/src/hotspot/share/opto/bytecodeInfo.cpp
+++ b/src/hotspot/share/opto/bytecodeInfo.cpp
@@ -156,18 +156,17 @@ bool InlineTree::should_inline(ciMethod* callee_method, ciMethod* caller_method,
   int invoke_count     = method()->interpreter_invocation_count();
 
   assert(invoke_count != 0, "require invocation count greater than zero");
-  int freq = call_site_count / invoke_count;
+  double freq = (double)call_site_count / (double)invoke_count;
 
   // bump the max size if the call is frequent
   if ((freq >= InlineFrequencyRatio) ||
-      (call_site_count >= InlineFrequencyCount) ||
       is_unboxing_method(callee_method, C) ||
       is_init_with_ea(callee_method, caller_method, C)) {
 
     max_inline_size = C->freq_inline_size();
     if (size <= max_inline_size && TraceFrequencyInlining) {
       CompileTask::print_inline_indent(inline_level());
-      tty->print_cr("Inlined frequent method (freq=%d count=%d):", freq, call_site_count);
+      tty->print_cr("Inlined frequent method (freq=%lf):", freq);
       CompileTask::print_inline_indent(inline_level());
       callee_method->print();
       tty->cr();

--- a/src/hotspot/share/runtime/globals.hpp
+++ b/src/hotspot/share/runtime/globals.hpp
@@ -1443,9 +1443,8 @@ const intx ObjectAlignmentInBytes = 8;
   product(intx, SpecTrapLimitExtraEntries,  3, EXPERIMENTAL,                \
           "Extra method data trap entries for speculation")                 \
                                                                             \
-  develop(intx, InlineFrequencyRatio,    20,                                \
+  product(double, InlineFrequencyRatio, 0.25, DIAGNOSTIC,                   \
           "Ratio of call site execution to caller method invocation")       \
-          range(0, max_jint)                                                \
                                                                             \
   product_pd(intx, InlineFrequencyCount, DIAGNOSTIC,                        \
           "Count of call site execution necessary to trigger frequent "     \

--- a/test/lib-test/jdk/test/whitebox/vm_flags/IntxTest.java
+++ b/test/lib-test/jdk/test/whitebox/vm_flags/IntxTest.java
@@ -36,7 +36,7 @@
 import jdk.test.lib.Platform;
 public class IntxTest {
     private static final String FLAG_NAME = "OnStackReplacePercentage";
-    private static final String FLAG_DEBUG_NAME = "InlineFrequencyCount";
+    private static final String FLAG_DEBUG_NAME = "BciProfileWidth";
     private static final long COMPILE_THRESHOLD = VmFlagTest.WHITE_BOX.getIntxVMFlag("CompileThreshold");
     private static final Long[] TESTS = {0L, 100L, (long)(Integer.MAX_VALUE>>3)*100L};
 


### PR DESCRIPTION
Summary: C2 considers absolute call site counts in its inlining decisions, which seems very wrong considering the asynchronous nature of profiling and background compilation (See InlineTree::should_inline()). It causes substantial over-inlining, which in presence of a depth-first inlining can lead to an early cut off. It also is inherently unstable. C2 already uses call frequency as an additional factor and it's better to consider only that in the inlining heuristic. The author did extensive benchmarking it yielded almost no losses and single-digit wins (up to 5%) on some benchmarks. The author think it's safe to remove/deprecate InlineFrequencyCount and continue using InlineFrequencyRatio instead. The author found that converting the frequency computation to FP and setting InlineFrequencyRatio=0.25 (inline a method that is called a least 25% of the time) works best.

Test Plan: ci jtreg

Reviewed-by: Kuaiwei, Wangzhuo

Issue: https://github.com/dragonwell-project/dragonwell17/issues/109