### PR TITLE
[Wisp] Remove JKU stack trace fp logic.

### DIFF
--- a/src/hotspot/share/runtime/coroutine.cpp
+++ b/src/hotspot/share/runtime/coroutine.cpp
@@ -467,17 +467,24 @@ void CoroutineStack::frames_do(FrameClosure* fc) {
   DEBUG_CORO_ONLY(tty->print_cr("frames_do stack %08x", _stack_base));
 
   intptr_t* fp = ((intptr_t**)_last_sp)[0];
-  if (fp != NULL) {
-    address pc = ((address*)_last_sp)[1];
-    intptr_t* sp = ((intptr_t*)_last_sp) + 2;
+  address pc = ((address*)_last_sp)[1];
+  intptr_t* sp = ((intptr_t*)_last_sp) + 2;
 
-    frame fr(sp, fp, pc);
-    StackFrameStream fst(_thread, fr, true /* update */, true /* process_frames */);
-    fst.register_map()->set_location(rbp->as_VMReg(), (address)_last_sp);
-    fst.register_map()->set_include_argument_oops(false);
-    for(; !fst.is_done(); fst.next()) {
-      fc->frames_do(fst.current(), fst.register_map());
-    }
+  frame fr(sp, fp, pc);
+
+#ifdef ASSERT
+  // if fp == NULL, it must be that frame pointer register is used as a general register
+  // in compiled code and the frame pointer register is written to 0 when the code's running.
+  if (fp == NULL) {
+    assert(fr.is_first_frame() || (!PreserveFramePointer && !fr.is_interpreted_frame() && CodeCache::find_blob(pc)), "FP is NULL only if sender frame is a JavaCalls::call() frame, or a compiler frame && -XX:-PreserveFramePointer");
+  }
+#endif
+
+  StackFrameStream fst(_thread, fr, true /* update */, true /* process_frames */);
+  fst.register_map()->set_location(rbp->as_VMReg(), (address)_last_sp);
+  fst.register_map()->set_include_argument_oops(false);
+  for(; !fst.is_done(); fst.next()) {
+    fc->frames_do(fst.current(), fst.register_map());
   }
 }
 
@@ -485,15 +492,20 @@ frame CoroutineStack::last_frame(Coroutine* coro, RegisterMap& map) const {
   DEBUG_CORO_ONLY(tty->print_cr("last_frame CoroutineStack"));
 
   intptr_t* fp = ((intptr_t**)_last_sp)[0];
-  assert(fp != NULL, "coroutine with NULL fp");
-
   address pc = ((address*)_last_sp)[1];
   intptr_t* sp = ((intptr_t*)_last_sp) + 2;
 
   map.set_location(rbp->as_VMReg(), (address)_last_sp);
   map.set_include_argument_oops(false);
 
-  return frame(sp, fp, pc);
+  frame f(sp, fp, pc);
+#ifdef ASSERT
+  if (fp == NULL) {
+    assert(f.is_first_frame() || (!PreserveFramePointer && !f.is_interpreted_frame() && CodeCache::find_blob(pc)), "FP is NULL only if sender frame is a JavaCalls::call() frame, or a compiler frame && -XX:-PreserveFramePointer");
+  }
+#endif
+
+  return f;
 }
 
 void Coroutine::print_stack_header_on(outputStream* st) {

--- a/test/hotspot/jtreg/runtime/coroutine/TestPreserveFramePointer.java
+++ b/test/hotspot/jtreg/runtime/coroutine/TestPreserveFramePointer.java
@@ -1,0 +1,55 @@
+/*
+ * @test
+ * @summary PreserveFramePointer for coroutine stack backtrace test
+ * @run main/othervm -XX:-UseBiasedLocking -XX:+EnableCoroutine -XX:+UseWispMonitor -Dcom.alibaba.wisp.transparentWispSwitch=true -Dcom.alibaba.wisp.version=2 -Xcomp -XX:TieredStopAtLevel=1 -XX:+PreserveFramePointer TestPreserveFramePointer
+ * @run main/othervm -XX:-UseBiasedLocking -XX:+EnableCoroutine -XX:+UseWispMonitor -Dcom.alibaba.wisp.transparentWispSwitch=true -Dcom.alibaba.wisp.version=2 -Xcomp -XX:TieredStopAtLevel=1 -XX:-PreserveFramePointer TestPreserveFramePointer
+ * @run main/othervm -XX:-UseBiasedLocking -XX:+EnableCoroutine -XX:+UseWispMonitor -Dcom.alibaba.wisp.transparentWispSwitch=true -Dcom.alibaba.wisp.version=2 -Xcomp -XX:-TieredCompilation -XX:+PreserveFramePointer TestPreserveFramePointer
+ * @run main/othervm -XX:-UseBiasedLocking -XX:+EnableCoroutine -XX:+UseWispMonitor -Dcom.alibaba.wisp.transparentWispSwitch=true -Dcom.alibaba.wisp.version=2 -Xcomp -XX:-TieredCompilation -XX:-PreserveFramePointer TestPreserveFramePointer
+ */
+
+
+import com.alibaba.wisp.engine.WispEngine;
+
+import java.util.concurrent.CountDownLatch;
+
+public class TestPreserveFramePointer {
+
+    private static Object lock = new Object();
+
+    private static final int COROUTINE_NUM = 100;
+
+    private static CountDownLatch cdl = new CountDownLatch(1);
+    private static CountDownLatch mainLock = new CountDownLatch(COROUTINE_NUM);
+
+    public static void main(String[] args) throws InterruptedException {
+
+        new Thread(() -> {                    // the lock holder thread to make lock contend
+            synchronized (lock) {
+                cdl.countDown();              // when we hold the lock, others can go on
+                try {
+                    Thread.sleep(100);  // hold the lock for 100ms so others contends
+                    System.gc();
+                } catch (InterruptedException e) {
+                    e.printStackTrace();
+                }
+            }
+            while (true) {}
+        }).start();
+
+        new Thread(() -> {
+            for (int i = 0; i < 100; i++) {
+                WispEngine.dispatch(() -> {
+                    try {
+                        cdl.await();
+                    } catch (InterruptedException e) {
+                        e.printStackTrace();
+                    }
+                    mainLock.countDown();
+                });
+            }
+        }).start();
+
+        mainLock.await();
+    }
+
+}

--- a/test/jdk/com/alibaba/wisp2/bug/TestPreemptWispInternalBug.java
+++ b/test/jdk/com/alibaba/wisp2/bug/TestPreemptWispInternalBug.java
@@ -61,8 +61,8 @@ public class TestPreemptWispInternalBug {
             return null;
         });
 
-        // Employ another new dedicated wisp task generate temporary objects
-        // garbage. Hope that it will can trigger many GCs and stop the other
+        // Employ another new dedicated wisp task to generate temporary objects
+        // garbage. Hope that it will trigger many GCs and stop the other
         // wisp task at POLL_AT_RETURN or POLL_AT_LOOP.
         FutureTask<Void> future2 = new FutureTask<>(() -> {
             Object task = SharedSecrets.getWispEngineAccess().getCurrentTask();


### PR DESCRIPTION
Summary: We'd remove the `fp == NULL` check: fp is useless in frame->sender() logic when frame is an entry frame (JavaCalls::call()) / compiled frame. Also, after using -XX:-PreserveFramePointer, the rbp register on X86 and the rfp register (alias x29 register) on AArch64 will be used as a general register which will be modified by the compiler.

Test Plan: all wisp tests, also run several days specjbb on ARM to test whether there's GC problem after this patch.

Reviewed-by: yulei

Issue:
https://github.com/dragonwell-project/dragonwell17/issues/121