### PR TITLE
[Wisp] Refactor platform related code and fix unstable tests.

### DIFF
--- a/src/hotspot/cpu/x86/coroutine_x86.cpp
+++ b/src/hotspot/cpu/x86/coroutine_x86.cpp
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2001-2010 Sun Microsystems, Inc.  All Rights Reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Sun Microsystems, Inc., 4150 Network Circle, Santa Clara,
+ * CA 95054 USA or visit www.sun.com if you need additional information or
+ * have any questions.
+ *
+ */
+
+#include "code/vmreg.hpp"
+#include "precompiled.hpp"
+#include "runtime/coroutine.hpp"
+#include "runtime/globals.hpp"
+#include "runtime/interfaceSupport.inline.hpp"
+#include "runtime/jniHandles.inline.hpp"
+#include "runtime/objectMonitor.hpp"
+#include "runtime/objectMonitor.inline.hpp"
+#include "services/threadService.hpp"
+
+#include CPU_HEADER(coroutine)
+#include CPU_HEADER_INLINE(vmreg)
+
+void Coroutine::set_coroutine_base(intptr_t **&base, JavaThread* thread, jobject obj, Coroutine *coro, oop coroutineObj, address coroutine_start) {
+  *(--base) = NULL;          // Make it to be 16 bytes(original is 8*5=40 bytes) aligned which be required by some instruction likes movaps otherwise we will incur crash.
+  *(--base) = NULL;
+  *(--base) = (intptr_t*)obj;
+  *(--base) = (intptr_t*)coro;
+  *(--base) = NULL;
+  *(--base) = (intptr_t*)coroutine_start;
+  *(--base) = NULL;
+}
+
+Register CoroutineStack::get_fp_reg() {
+  return rbp;
+}

--- a/src/hotspot/cpu/x86/coroutine_x86.hpp
+++ b/src/hotspot/cpu/x86/coroutine_x86.hpp
@@ -1,0 +1,31 @@
+/*
+ * Copyright 1999-2010 Sun Microsystems, Inc.  All Rights Reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Sun Microsystems, Inc., 4150 Network Circle, Santa Clara,
+ * CA 95054 USA or visit www.sun.com if you need additional information or
+ * have any questions.
+ *
+ */
+
+#ifndef CPU_X86_VM_COROUTINE_X86_HPP
+#define CPU_X86_VM_COROUTINE_X86_HPP
+
+#define R_TH r15
+#define WISP_j2v_UPDATE __ movptr(thread, R_TH)
+
+#endif // CPU_X86_VM_COROUTINE_X86_HPP

--- a/src/hotspot/cpu/x86/sharedRuntime_x86_64.cpp
+++ b/src/hotspot/cpu/x86/sharedRuntime_x86_64.cpp
@@ -1545,7 +1545,7 @@ void generate_thread_fix(MacroAssembler *masm, Method *method) {
       // see: https://www.cs.cmu.edu/~aplatzer/course/Compilers11/calling_conventions.pdf, callee saved registers
       // the r15 register will be saved at method entry, and restored implicitly at method exit
       // so we have to fix it manually here after the method returns.
-      WISP_X86_CONVENTION_V2J_UPDATE;
+      WISP_CALLING_CONVENTION_V2J_UPDATE;
     }
   }
 }

--- a/src/hotspot/cpu/x86/templateInterpreterGenerator_x86.cpp
+++ b/src/hotspot/cpu/x86/templateInterpreterGenerator_x86.cpp
@@ -1007,7 +1007,7 @@ address TemplateInterpreterGenerator::generate_native_entry(bool synchronized) {
   if (EnableCoroutine) {
     // it is a little hard to present method signature check here: because interpreter
     // will directly jump into this entry, which is in runtime.
-    WISP_X86_CONVENTION_V2j_UPDATE;
+    WISP_CALLING_CONVENTION_V2j_UPDATE;
   }
 
   // Verify or restore cpu control state after JNI call

--- a/src/hotspot/share/runtime/coroutine.hpp
+++ b/src/hotspot/share/runtime/coroutine.hpp
@@ -25,6 +25,7 @@
 #ifndef SHARE_VM_RUNTIME_COROUTINE_HPP
 #define SHARE_VM_RUNTIME_COROUTINE_HPP
 
+#include "asm/register.hpp"
 #include "classfile/javaThreadStatus.hpp"
 #include "classfile/vmSymbols.hpp"
 #include "runtime/jniHandles.hpp"
@@ -138,6 +139,8 @@ private:
   Coroutine() { }
 
   void frames_do(FrameClosure* fc);
+
+  static void set_coroutine_base(intptr_t **&base, JavaThread* thread, jobject obj, Coroutine *coro, oop coroutineObj, address coroutine_start);
 
 public:
   virtual ~Coroutine();
@@ -274,6 +277,8 @@ private:
   // objects of this type can only be created via static functions
   CoroutineStack(intptr_t size) : _reserved_space(size) { }
   virtual ~CoroutineStack() { }
+
+  static Register get_fp_reg();
 
 public:
   static CoroutineStack* create_thread_stack(JavaThread* thread);
@@ -540,11 +545,13 @@ public:
 //    V: VM frame (C/C++)
 //    v: Other frames running VM generated code (e.g. stubs, adapters, etc.)
 //    C: C/C++ frame
-#define WISP_THREAD_UPDATE get_thread(r15)
-#define WISP_X86_CONVENTION_V2J_UPDATE __ WISP_THREAD_UPDATE
-#define WISP_X86_CONVENTION_V2j_UPDATE __ WISP_THREAD_UPDATE
+#ifdef X86
+#include CPU_HEADER(coroutine)
+#endif
+#define WISP_THREAD_UPDATE get_thread(R_TH)
+#define WISP_CALLING_CONVENTION_V2J_UPDATE __ WISP_THREAD_UPDATE
+#define WISP_CALLING_CONVENTION_V2j_UPDATE __ WISP_THREAD_UPDATE
 #define WISP_COMPILER_RESTORE_FORCE_UPDATE __ WISP_THREAD_UPDATE
-#define WISP_j2v_UPDATE __ movptr(thread, r15_thread)
 #define WISP_V2v_UPDATE WISP_THREAD_UPDATE
 
 class WispPostStealHandleUpdateMark;

--- a/test/jdk/com/alibaba/wisp/monitor/TestMultiThread.java
+++ b/test/jdk/com/alibaba/wisp/monitor/TestMultiThread.java
@@ -4,7 +4,7 @@
  * @summary Test object lock with coroutine
  * @modules java.base/jdk.internal.access
  * @run main/othervm  -XX:-UseBiasedLocking -XX:+EnableCoroutine -XX:+UseWispMonitor -Dcom.alibaba.wisp.transparentWispSwitch=true TestMultiThread
-*/
+ */
 
 
 import com.alibaba.wisp.engine.WispEngine;
@@ -92,53 +92,50 @@ public class TestMultiThread {
             this.ord = ord;
         }
 
-        @Override
-        public void run() {
-            while (current < N) {
-                if (JUC) {
-                    lock.lock();
-                    try {
-                        while (current % runners.length != ord) {
-                            try {
-                                //System.out.println("wait" + SharedSecrets.getJavaLangAccess().currentThread0().getName());
-                                cond.await();
-                            } catch (InterruptedException e) {
-                                e.printStackTrace();
-                            }
+        private void runJUC() {
+            lock.lock();
+            try {
+                while (current < N) {
+                    while (current % runners.length != ord) {
+                        try {
+                            cond.await();
+                        } catch (InterruptedException e) {
+                            e.printStackTrace();
                         }
-                        if (++current % 10000 == 0) // pass the token
-                            System.out.println(SharedSecrets.getJavaLangAccess().currentThread0().getName() + "\t" + current);
-                    } finally {
-                        lock.unlock();
                     }
-                } else {
-                    synchronized (lock) {
-                        while (current % runners.length != ord) {
-                            try {
-                                lock.wait();
-                            } catch (InterruptedException e) {
-                                e.printStackTrace();
-                            }
-                        }
-                        if (++current % 10000 == 0) // pass the token
-                            System.out.println(SharedSecrets.getJavaLangAccess().currentThread0().getName() + "\t" + current);
-                    }
+                    if (++current % 10000 == 0) // pass the token
+                        System.out.println(SharedSecrets.getJavaLangAccess().currentThread0().getName() + "\t" + current);
+                    cond.signalAll();
                 }
+            } finally {
+                lock.unlock();
+            }
+        }
 
-                if (JUC) {
-                    lock.lock();
-                    try {
-                        cond.signalAll();
-                    } finally {
-                        lock.unlock();
+        private void runMonitor() {
+            synchronized (lock) {
+                while (current < N) {
+                    while (current % runners.length != ord) {
+                        try {
+                            lock.wait();
+                        } catch (InterruptedException e) {
+                            e.printStackTrace();
+                        }
                     }
-                } else {
-                    synchronized (lock) {
-                        lock.notifyAll();
-                    }
+                    if (++current % 10000 == 0) // pass the token
+                        System.out.println(SharedSecrets.getJavaLangAccess().currentThread0().getName() + "\t" + current);
+                    lock.notifyAll();
                 }
             }
-            System.out.println(SharedSecrets.getJavaLangAccess().currentThread0().getName() + " down"); 
+        }
+
+        @Override
+        public void run() {
+            if (JUC) {
+                runJUC();
+            } else {
+                runMonitor();
+            }
             finishLatch.countDown();
         }
     }


### PR DESCRIPTION
Summary: 
1. move all platform related code (currently X86 only) to the `hotspot/cpu/` directory
2. Fix unstable tests for Wisp:
multi-tenant/TestKillThreadWithWisp.java
related to code change Wisp2Group -> WispEngine

com/alibaba/wisp/monitor/TestMultiThread.java
test case issue if the task runs too slowly, the process can't exit as
expected.

Test Plan: all wisp tests

Reviewed-by: yulei

Issue:
https://github.com/dragonwell-project/dragonwell17/issues/123